### PR TITLE
Enable setting FILTER on variant records

### DIFF
--- a/cyvcf2/__init__.py
+++ b/cyvcf2/__init__.py
@@ -2,4 +2,4 @@
 from .cyvcf2 import VCF, Variant, Writer, r_ as r_unphased
 Reader = VCFReader = VCF
 
-__version__ = "0.2.3"
+__version__ = "0.2.4"

--- a/cyvcf2/cyvcf2.pxd
+++ b/cyvcf2/cyvcf2.pxd
@@ -215,6 +215,7 @@ cdef extern from "htslib/vcf.h":
     bcf_info_t *bcf_get_info(const bcf_hdr_t *hdr, bcf1_t *line, const char *key);
 
     int bcf_update_info(const bcf_hdr_t *hdr, bcf1_t *line, const char *key, const void *values, int n, int type);
+    int bcf_update_filter(const bcf_hdr_t *hdr, bcf1_t *line, int *flt_ids, int n);
 
 
     int bcf_add_id(const bcf_hdr_t *hdr, bcf1_t *line, const char *id);

--- a/cyvcf2/cyvcf2.pyx
+++ b/cyvcf2/cyvcf2.pyx
@@ -1068,6 +1068,15 @@ cdef class Variant(object):
                         return None
                     return v
             return ';'.join(bcf_hdr_int2id(h, BCF_DT_ID, self.b.d.flt[i]) for i in range(n))
+        def __set__(self, filters):
+            cdef bcf_hdr_t *h = self.vcf.hdr
+            cdef int *flt_ids = <int *>stdlib.malloc(sizeof(int) * len(filters))
+            for i, fname in enumerate(filters):
+                flt_ids[i] = bcf_hdr_id2int(h, BCF_DT_ID, fname)
+            ret = bcf_update_filter(h, self.b, flt_ids, len(filters))
+            stdlib.free(flt_ids)
+            if ret != 0:
+                raise Exception("not able to set filter: %s", filters)
 
     property QUAL:
         def __get__(self):
@@ -1133,7 +1142,7 @@ cdef class INFO(object):
         try:
             return self.__getitem__(key)
         except KeyError:
-            return None
+            return default
 
     def __iter__(self):
         self._i = 0

--- a/cyvcf2/tests/test_reader.py
+++ b/cyvcf2/tests/test_reader.py
@@ -149,6 +149,11 @@ def test_attrs():
 def test_writer():
     v = VCF(VCF_PATH)
     o = Writer("/dev/stdout", v)
+    rec = v.next()
+    rec.INFO["AC"] = "3"
+    rec.FILTER = ["Filter1", "Filter2"]
+    rec.FILTER = ["PASS"]
+    o.write_record(rec)
     o.close()
     del o
 


### PR DESCRIPTION
Brent;
I'm using cyvcf2 to update filters (providing a VCF file of germline variants from those filtered by a standard somatic tumor/normal pipeline). This enables setting the filters provided a list of filter names that exist in the header. Longer term it would be great to also be able to add new filters, but this works for my immediate needs. I'd be happy for any checks on this as I'm not too experiences with cython. Thanks much.