### PR TITLE
fix compiler warnings

### DIFF
--- a/cyvcf2/cyvcf2.pxd
+++ b/cyvcf2/cyvcf2.pxd
@@ -86,7 +86,7 @@ cdef extern from "htslib/vcf.h":
     const int bcf_int8_vector_end  = -127
     const int bcf_int16_vector_end  = -32767
     const int bcf_int32_vector_end  = -2147483647
-    
+
     const int bcf_int8_missing  = -127
     const int bcf_int16_missing  = -32767
     const int bcf_int32_missing  = -2147483647
@@ -100,7 +100,7 @@ cdef extern from "htslib/vcf.h":
         pass
 
     ctypedef struct bcf_fmt_t:
-        int n; # n 
+        int n; # n
 
     ctypedef struct bcf_info_t:
         int key;        # key: numeric tag id, the corresponding string is bcf_hdr_t::id[BCF_DT_ID][$key].key
@@ -118,7 +118,8 @@ cdef extern from "htslib/vcf.h":
         int m_fmt, m_info, m_id, m_als, m_allele, m_flt; # allocated size (high-water mark); do not change
         int n_flt;  # Number of FILTER fields
         int *flt;   # FILTER keys in the dictionary
-        char *id, *als;     # ID and REF+ALT block (\0-seperated)
+        char *id;      # ID block (\0-seperated)
+        char *als;     # REF+ALT block (\0-seperated)
         char **allele;      # allele[0] is the REF (allele[] pointers to the als block); all null terminated
         bcf_info_t *info;   # INFO
         bcf_fmt_t *fmt;     # FORMAT and individual sample
@@ -156,7 +157,8 @@ cdef extern from "htslib/vcf.h":
         char *key;      # The part before '=', i.e. FILTER/INFO/FORMAT/contig/fileformat etc.
         char *value;    # Set only for generic lines, NULL for FILTER/INFO, etc.
         int nkeys;              # Number of structured fields
-        char **keys, **vals;    # The key=value pairs
+        char **keys;    # The key=value pairs
+        char **vals;    # The key=value pairs
 
     ctypedef struct kstring_t:
         pass
@@ -168,7 +170,8 @@ cdef extern from "htslib/vcf.h":
         char **samples;
         bcf_hrec_t **hrec;
         int nhrec, dirty;
-        int ntransl, *transl[2]; # for bcf_translate()
+        int ntransl;    # for bcf_translate()
+        int *transl[2]; # for bcf_translate()
         int nsamples_ori;        # for bcf_hdr_set_samples()
         uint8_t *keep_samples;
         kstring_t mem;

--- a/cyvcf2/cyvcf2.pyx
+++ b/cyvcf2/cyvcf2.pyx
@@ -1,4 +1,4 @@
-#cython: profile=True, language_level=3
+#cython: profile=True
 import os
 import os.path as op
 import sys
@@ -873,7 +873,7 @@ cdef class Variant(object):
                 self._gt_phased = <int *>stdlib.malloc(sizeof(int) * self.vcf.n_samples)
                 ndst = 0
                 ngts = bcf_get_genotypes(self.vcf.hdr, self.b, &self._gt_types, &ndst)
-                nper = ndst // self.vcf.n_samples
+                nper = ndst / self.vcf.n_samples
                 self._ploidy = nper
                 self._gt_idxs = <int *>stdlib.malloc(sizeof(int) * self.vcf.n_samples * nper)
                 if ndst == 0 or nper == 0:
@@ -927,7 +927,7 @@ cdef class Variant(object):
                         if self._gt_pls[i] < 0:
                             self._gt_pls[i] = imax
 
-                self._gt_nper = nret // self.vcf.n_samples
+                self._gt_nper = nret / self.vcf.n_samples
             cdef np.npy_intp shape[1]
             shape[0] = <np.npy_intp> self._gt_nper * self.vcf.n_samples
             if self._gt_pls != NULL:
@@ -998,7 +998,7 @@ cdef class Variant(object):
                 # GATK
                 nret = bcf_get_format_int32(self.vcf.hdr, self.b, "AD", &self._gt_ref_depths, &ndst)
                 if nret > 0:
-                    nper = nret // self.vcf.n_samples
+                    nper = nret / self.vcf.n_samples
                     if nper == 1:
                         stdlib.free(self._gt_ref_depths); self._gt_ref_depths = NULL
                         return -1 + np.zeros(self.vcf.n_samples, np.int32)
@@ -1039,7 +1039,7 @@ cdef class Variant(object):
                 # GATK
                 nret = bcf_get_format_int32(self.vcf.hdr, self.b, "AD", &self._gt_alt_depths, &ndst)
                 if nret > 0:
-                    nper = nret // self.vcf.n_samples
+                    nper = nret / self.vcf.n_samples
                     if nper == 1:
                         stdlib.free(self._gt_alt_depths); self._gt_alt_depths = NULL
                         return (-1 + np.zeros(self.vcf.n_samples, np.int32))
@@ -1054,7 +1054,7 @@ cdef class Variant(object):
                 elif nret == -1:
                     # Freebayes
                     nret = bcf_get_format_int32(self.vcf.hdr, self.b, "AO", &self._gt_alt_depths, &ndst)
-                    nper = nret // self.vcf.n_samples
+                    nper = nret / self.vcf.n_samples
                     if nret < 0:
                         stdlib.free(self._gt_alt_depths); self._gt_alt_depths = NULL
                         return -1 + np.zeros(self.vcf.n_samples, np.int32)


### PR DESCRIPTION
The typing of `idx0` and `idx1` (l.271) is an optimization suggested by the compiler. 

The separate lines for some var definitions in the .pdx fix some compile-time warnings (pointer and value defined in the same type definition).