### PR TITLE
Prevent segfault when 'Variant' gets initialised

### DIFF
--- a/cyvcf2/cyvcf2.pyx
+++ b/cyvcf2/cyvcf2.pyx
@@ -743,6 +743,9 @@ cdef class Variant(object):
 
     cdef readonly int POS
 
+    def __init__(self, *args, **kwargs):
+        raise TypeError("Variant object cannot be instantiated directly.")
+
     def __cinit__(self):
         self.b = NULL
         self._gt_types = NULL

--- a/cyvcf2/tests/test_reader.py
+++ b/cyvcf2/tests/test_reader.py
@@ -133,6 +133,9 @@ def test_next():
     variant = next(v)
     assert isinstance(variant, Variant)
 
+def test_variant():
+    assert_raises(TypeError, Variant)
+
 def test_info_dict():
     v = VCF(VCF_PATH)
     variant = next(v)


### PR DESCRIPTION
Avoids a segfault in case the user tries to create a `Variant` object directly.