### PR TITLE
setup_requires

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,3 @@
-[wheel]
-universal=1
-[bdist_wheel]
-universal=1
 [nosetests]
 verbosity=1
 detailed-errors=1

--- a/setup.py
+++ b/setup.py
@@ -31,13 +31,22 @@ sources = [x for x in glob.glob('htslib/*.c') if not any(e in x for e in exclude
 sources = [x for x in sources if not x.endswith(('htsfile.c', 'tabix.c', 'bgzip.c'))]
 sources.append('cyvcf2/helpers.c')
 
-import numpy as np
-from Cython.Distutils import build_ext
-cmdclass = {'build_ext': build_ext}
-extension = [Extension("cyvcf2.cyvcf2",
-                        ["cyvcf2/cyvcf2.pyx"] + sources,
-                        libraries=['z'],
-                        include_dirs=['htslib', 'cyvcf2', np.get_include()])]
+# When pip calls setup.py egg_info to get metadata, do not import
+# any of the dependencies
+if '--help' in sys.argv[1:] or \
+        sys.argv[1] in ('--help-commands', 'egg_info', 'clean', '--version'):
+    cmdclass = {}
+    extension = []
+else:
+    import numpy as np
+    from Cython.Distutils import build_ext
+    cmdclass = {'build_ext': build_ext}
+    extension = [Extension("cyvcf2.cyvcf2",
+                            ["cyvcf2/cyvcf2.pyx"] + sources,
+                            libraries=['z'],
+                            include_dirs=['htslib', 'cyvcf2', np.get_include()])]
+
+requires = ['cython>=0.22.1', 'numpy']
 
 setup(
     name="cyvcf2",
@@ -53,7 +62,8 @@ setup(
     packages=['cyvcf2', 'cyvcf2.tests'],
     test_suite='nose.collector',
     tests_require='nose',
-    install_requires=['cython>=0.22.1', 'numpy'],
+    install_requires=requires,
+    setup_requires=requires,
     include_package_data=True,
     zip_safe=False,
 )

--- a/setup.py
+++ b/setup.py
@@ -1,13 +1,14 @@
-from setuptools import setup
-from setuptools import Extension
+from setuptools import setup, Extension
 import os
 import glob
-
 import sys
+import subprocess
+import pkg_resources
 
 if sys.version_info.major == 2 and sys.version_info.minor != 7:
     sys.stderr.write("ERROR: cyvcf2 is only for python 2.7 or greater you are running %d.%d\n", (sys.version_info.major, sys.version_info.minor))
     sys.exit(1)
+
 
 def get_version():
     """Get the version info from the mpld3 package without importing it"""
@@ -24,6 +25,34 @@ def get_version():
     except StopIteration:
           raise ValueError("version could not be located")
 
+
+# Temporarily install dependencies required by setup.py before trying to import them.
+# From https://bitbucket.org/dholth/setup-requires
+
+sys.path[0:0] = ['setup-requires']
+pkg_resources.working_set.add_entry('setup-requires')
+
+
+def missing_requirements(specifiers):
+    for specifier in specifiers:
+        try:
+            pkg_resources.require(specifier)
+        except pkg_resources.DistributionNotFound:
+            yield specifier
+
+
+def install_requirements(specifiers):
+    to_install = list(specifiers)
+    if to_install:
+        cmd = [sys.executable, "-m", "pip", "install",
+            "-t", "setup-requires"] + to_install
+        subprocess.call(cmd)
+
+
+requires = ['cython', 'numpy']
+install_requirements(missing_requirements(requires))
+
+
 excludes = ['irods', 'plugin']
 
 sources = [x for x in glob.glob('htslib/*.c') if not any(e in x for e in excludes)] + glob.glob('htslib/cram/*.c')
@@ -31,22 +60,15 @@ sources = [x for x in glob.glob('htslib/*.c') if not any(e in x for e in exclude
 sources = [x for x in sources if not x.endswith(('htsfile.c', 'tabix.c', 'bgzip.c'))]
 sources.append('cyvcf2/helpers.c')
 
-# When pip calls setup.py egg_info to get metadata, do not import
-# any of the dependencies
-if '--help' in sys.argv[1:] or \
-        sys.argv[1] in ('--help-commands', 'egg_info', 'clean', '--version'):
-    cmdclass = {}
-    extension = []
-else:
-    import numpy as np
-    from Cython.Distutils import build_ext
-    cmdclass = {'build_ext': build_ext}
-    extension = [Extension("cyvcf2.cyvcf2",
-                            ["cyvcf2/cyvcf2.pyx"] + sources,
-                            libraries=['z'],
-                            include_dirs=['htslib', 'cyvcf2', np.get_include()])]
+import numpy as np
+from Cython.Distutils import build_ext
 
-requires = ['cython>=0.22.1', 'numpy']
+cmdclass = {'build_ext': build_ext}
+extension = [Extension("cyvcf2.cyvcf2",
+                        ["cyvcf2/cyvcf2.pyx"] + sources,
+                        libraries=['z'],
+                        include_dirs=['htslib', 'cyvcf2', np.get_include()])]
+
 
 setup(
     name="cyvcf2",
@@ -62,8 +84,7 @@ setup(
     packages=['cyvcf2', 'cyvcf2.tests'],
     test_suite='nose.collector',
     tests_require='nose',
-    install_requires=requires,
-    setup_requires=requires,
+    install_requires=['numpy'],
     include_package_data=True,
     zip_safe=False,
 )

--- a/setup.py
+++ b/setup.py
@@ -31,26 +31,13 @@ sources = [x for x in glob.glob('htslib/*.c') if not any(e in x for e in exclude
 sources = [x for x in sources if not x.endswith(('htsfile.c', 'tabix.c', 'bgzip.c'))]
 sources.append('cyvcf2/helpers.c')
 
-install_requires = []
-try:
-    import numpy as np
-except ImportError:
-    install_requires.append("numpy")
-
-try:
-    from Cython.Distutils import build_ext
-except ImportError:
-    install_requires.append("cython>=0.22.1")
-
-if not install_requires:
-    cmdclass = {'build_ext': build_ext}
-    extension = [Extension("cyvcf2.cyvcf2",
-                           ["cyvcf2/cyvcf2.pyx"] + sources,
-                           libraries=['z'],
-                           include_dirs=['htslib', 'cyvcf2', np.get_include()])]
-else:
-    cmdclass = {}
-    extension = []
+import numpy as np
+from Cython.Distutils import build_ext
+cmdclass = {'build_ext': build_ext}
+extension = [Extension("cyvcf2.cyvcf2",
+                        ["cyvcf2/cyvcf2.pyx"] + sources,
+                        libraries=['z'],
+                        include_dirs=['htslib', 'cyvcf2', np.get_include()])]
 
 setup(
     name="cyvcf2",
@@ -66,7 +53,7 @@ setup(
     packages=['cyvcf2', 'cyvcf2.tests'],
     test_suite='nose.collector',
     tests_require='nose',
-    install_requires=install_requires,
+    install_requires=['cython>=0.22.1', 'numpy'],
     include_package_data=True,
     zip_safe=False,
 )


### PR DESCRIPTION
This attempts to fix #28. Please see the individual commit messages, in particular for 39d7a37.

The solution of spawning a `pip install` subprocess while executing `setup.py` feels a bit weird, but it works, which I cannot say for anything else I tried. It should not interfere with conda packaging, but maybe that needs to be tested.

It would also be nice to provide manylinux1 wheels, which would be a different solution to the problem.