### PR TITLE
Fix error while running compare.sh

### DIFF
--- a/scripts/filter-pyvcf.py
+++ b/scripts/filter-pyvcf.py
@@ -2,7 +2,7 @@ import sys
 from vcf import Reader
 import gzip
 
-vcf = Reader(open(sys.argv[1], 'r'))
+vcf = Reader(open(sys.argv[1], 'rb'))
 n = 0
 
 for v in vcf:


### PR DESCRIPTION
bash compare.sh 
#pyvcf
Traceback (most recent call last):
  File "filter-pyvcf.py", line 5, in <module>
    vcf = Reader(open(sys.argv[1], 'rt'))
  File "/home/raony/.virtualenvs/cuvcf2/lib/python3.5/site-packages/vcf/parser.py", line 300, in __init__
    self._parse_metainfo()
  File "/home/raony/.virtualenvs/cuvcf2/lib/python3.5/site-packages/vcf/parser.py", line 317, in _parse_metainfo
    line = next(self.reader)
  File "/home/raony/.virtualenvs/cuvcf2/lib/python3.5/site-packages/vcf/parser.py", line 280, in <genexpr>
    self.reader = (line.strip() for line in self._reader if line.strip())
  File "/home/raony/.virtualenvs/cuvcf2/lib/python3.5/codecs.py", line 642, in __next__
    line = self.readline()
  File "/home/raony/.virtualenvs/cuvcf2/lib/python3.5/codecs.py", line 555, in readline
    data = self.read(readsize, firstline=True)
  File "/home/raony/.virtualenvs/cuvcf2/lib/python3.5/codecs.py", line 495, in read
    newdata = self.stream.read(size)
  File "/usr/lib/python3.5/gzip.py", line 274, in read
    return self._buffer.read(size)
  File "/usr/lib/python3.5/_compression.py", line 68, in readinto
    data = self.read(len(byte_view))
  File "/usr/lib/python3.5/gzip.py", line 461, in read
    if not self._read_gzip_header():
  File "/usr/lib/python3.5/gzip.py", line 404, in _read_gzip_header
    magic = self._fp.read(2)
  File "/usr/lib/python3.5/gzip.py", line 91, in read
    self.file.read(size-self._length+read)
  File "/home/raony/.virtualenvs/cuvcf2/lib/python3.5/codecs.py", line 321, in decode
    (result, consumed) = self._buffer_decode(data, self.errors, final)
UnicodeDecodeError: 'utf-8' codec can't decode byte 0x8b in position 1: invalid start byte

real	0m0.085s
user	0m0.072s
sys	0m0.012s