### PR TITLE
Fix err reporting on missing samples in VCF

### DIFF
--- a/cyvcf2/cyvcf2.pyx
+++ b/cyvcf2/cyvcf2.pyx
@@ -288,7 +288,7 @@ cdef class VCF:
         ret = bcf_hdr_set_samples(self.hdr, <const char *>samples, 0)
         assert ret >= 0, ("error setting samples", ret)
         if ret != 0 and samples != "-":
-            s = samples.split(",")
+            s = from_bytes(samples).split(",")
             if ret < len(s):
                 sys.stderr.write("warning: not all requested samples found in VCF\n")
 

--- a/cyvcf2/tests/test_reader.py
+++ b/cyvcf2/tests/test_reader.py
@@ -59,6 +59,7 @@ def test_write_format_str():
 def test_missing_samples():
     samples = ['101976-101976', 'sample_not_in_vcf']
     vcf = VCF(VCF_PATH, gts012=True, samples=samples)
+    assert len(vcf.samples) == 1
 
 def test_ibd():
     samples = ['101976-101976', '100920-100920', '100231-100231']

--- a/cyvcf2/tests/test_reader.py
+++ b/cyvcf2/tests/test_reader.py
@@ -56,6 +56,10 @@ def test_write_format_str():
     assert "35" in str(variant) 
     """
 
+def test_missing_samples():
+    samples = ['101976-101976', 'sample_not_in_vcf']
+    vcf = VCF(VCF_PATH, gts012=True, samples=samples)
+
 def test_ibd():
     samples = ['101976-101976', '100920-100920', '100231-100231']
     vcf = VCF(VCF_PATH, gts012=True, samples=samples)


### PR DESCRIPTION
Minor fix to prevent 
```
...
    vcf = cyvcf2.VCF(vcf, gts012=True, samples=[x.sample_id for x in ped_samples])
  File "cyvcf2/cyvcf2.pyx", line 202, in cyvcf2.cyvcf2.VCF.__init__
  File "cyvcf2/cyvcf2.pyx", line 291, in cyvcf2.cyvcf2.VCF.set_samples
TypeError: a bytes-like object is required, not 'str'
```
when samples are missing from VCF.