### PR TITLE
Support for phased genotypes as numpy arrays

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,4 +17,3 @@ _build
 _static
 _templates
 setup-requires/*
-.cache/v/cache/lastfailed

--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ libhts.a
 _build
 _static
 _templates
+setup-requires/*

--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ _build
 _static
 _templates
 setup-requires/*
+.cache/v/cache/lastfailed

--- a/cyvcf2/cyvcf2.pyx
+++ b/cyvcf2/cyvcf2.pyx
@@ -1181,13 +1181,13 @@ cdef class Variant(object):
             cdef int32_t *gts = NULL
             cdef int i, j, nret = 0, ndst = 0, k = 0, ell = 0
             cdef int n_samples = self.vcf.n_samples
+            nret = bcf_get_genotypes(self.vcf.hdr, self.b, &gts, &ndst)
+            if nret < 0:
+                raise Exception("error parsing genotypes")
+            nret /= n_samples
             if self.vcf.n_samples == 0:
                 return np.array([]), np.array([])
             if self._numpy_genotypes == NULL:
-                nret = bcf_get_genotypes(self.vcf.hdr, self.b, &gts, &ndst)
-                if nret < 0:
-                    raise Exception("error parsing genotypes")
-                nret /= n_samples
                 self._numpy_genotypes = <int32_t *>stdlib.malloc(sizeof(int) * n_samples * (nret+1))
                 for i in range(n_samples):
                     k = i * nret

--- a/cyvcf2/cyvcf2.pyx
+++ b/cyvcf2/cyvcf2.pyx
@@ -1181,13 +1181,13 @@ cdef class Variant(object):
             cdef int32_t *gts = NULL
             cdef int i, j, nret = 0, ndst = 0, k = 0, ell = 0
             cdef int n_samples = self.vcf.n_samples
+            nret = bcf_get_genotypes(self.vcf.hdr, self.b, &gts, &ndst)
+            if nret < 0:
+                raise Exception("error parsing genotypes")
+            nret /= n_samples
             if self.vcf.n_samples == 0:
                 return np.array([]), np.array([])
             if self._numpy_genotypes == NULL:
-                nret = bcf_get_genotypes(self.vcf.hdr, self.b, &gts, &ndst)
-                if nret < 0:
-                    raise Exception("error parsing genotypes")
-                nret /= n_samples
                 self._numpy_genotypes = <int32_t *>stdlib.malloc(sizeof(int) * n_samples * (nret+1))
                 for i in range(n_samples):
                     k = i * nret
@@ -1206,92 +1206,6 @@ cdef class Variant(object):
             shape[0] = <np.npy_intp> self.vcf.n_samples
             shape[1] = <np.npy_intp> (nret + 1)
             to_return = np.PyArray_SimpleNewFromData(2, shape, np.NPY_INT32, self._numpy_genotypes)
-            return to_return[:,:-1], to_return[:,-1].astype(bool)
-
-        def __set__(self, gts_and_phase):
-            gts, phase = gts_and_phase
-            cdef int n_samples = self.vcf.n_samples
-            if gts.shape[0] != n_samples:
-                raise Exception("numpy_genotypes: must set with a number of gts "
-                                "equal to the number of samples in the vcf.")
-            elif gts.shape[0] == 0:
-                nret = 0
-            else:
-                nret = gts.shape[1]
-            cdef int * cgts = <int *>stdlib.malloc(sizeof(int) * nret * n_samples)
-            cdef int i, j, k
-            self._numpy_genotypes = NULL
-            self._genotypes = None
-
-            for i in range(n_samples):
-                k = i * nret
-                for j in range(nret):
-                    if gts[i, j] == -2:
-                        cgts[k + j] = bcf_int32_vector_end
-                        break
-                    else:
-                        cgts[k + j] = (bcf_gt_phased(gts[i, j]) if phase[i]
-                                       else bcf_gt_unphased(gts[i, j]))
-            ret = bcf_update_genotypes(self.vcf.hdr, self.b, cgts, n_samples * nret)
-            if ret < 0:
-                raise Exception("error setting genotypes with: %s and %s" % (gts, phase))
-            stdlib.free(cgts)
-
-    def genotype(self):
-        if self.vcf.n_samples == 0: return None
-        cdef int32_t *gts = NULL
-        cdef int ndst = 0
-        cdef int nret = bcf_get_genotypes(self.vcf.hdr, self.b, &gts, &ndst)
-
-    property genotypes:
-        """genotypes returns a list for each sample Indicating the allele and phasing.
-
-        e.g. [0, 1, True] corresponds to 0|1
-        while [1, 2, False] corresponds to 1/2
-        """
-        def __get__(self):
-            if self.vcf.n_samples == 0: return None
-            if self._genotypes is not None:
-              return self._genotypes
-            cdef int32_t *gts = NULL
-            cdef int i, j, nret, off = 0, ndst = 0, k = 0
-            cdef int n_samples = self.vcf.n_samples
-            #self._genotypes = []
-            nret = bcf_get_genotypes(self.vcf.hdr, self.b, &gts, &ndst)
-            if nret < 0:
-                raise Exception("error parsing genotypes")
-            nret /= n_samples
-            self._genotypes = [[] for _ in range(n_samples)]
-
-            for i in range(n_samples):
-              k = i * nret
-              for j in range(nret):
-                  #assert k + j < ndst
-                  if bcf_gt_is_missing(gts[k + j]):
-                      self._genotypes[i].append(-1)
-                      continue
-                  if gts[k + j] == bcf_int32_vector_end:
-                      break
-                  self._genotypes[i].append(bcf_gt_allele(gts[k + j]))
-              self._genotypes[i].append(
-                    bool(bcf_gt_is_phased(gts[k+1 if k+1 < ndst else k])))
-
-            stdlib.free(gts)
-            return self._genotypes
-
-        def __set__(self, gts):
-            cdef int n_samples = self.vcf.n_samples
-            if len(gts) != n_samples:
-                raise Exception("genotypes: must set with a number of gts equal the number of samples in the vcf")
-            elif len(gts) == 0:
-                nret = 0
-            else:
-                nret = max(len(gt)-1 for gt in gts)
-            cdef int * cgts = <int *>stdlib.malloc(sizeof(int) * nret * n_samples)
-            cdef int i, j, k
-            self._genotypes = None
-            self._numpy_genotypes = NULL
-
             for i in range(n_samples):
                 k = i * nret
                 for j in range(nret):

--- a/cyvcf2/tests/test_reader.py
+++ b/cyvcf2/tests/test_reader.py
@@ -625,6 +625,47 @@ def test_set_gts():
     
     v.genotypes = [[0, 1, 2, False], [0, 1, 2, True]]
     assert get_gt_str(v) == ["0/1/2", "0|1|2"]
+    assert np.all(v.numpy_genotypes[0] == np.array([[0, 1, 2], [0, 1, 2]]))
+    assert np.all(v.numpy_genotypes[1] == np.array([False, True]))
+
+def test_set_numpy_gts():
+    vcf = VCF('{}/test-format-string.vcf'.format(HERE))
+    v = next(vcf)
+
+    v.numpy_genotypes = (np.array([[1, 1], [0, 0]]),
+                         np.array([True, False]))
+    assert get_gt_str(v) == ["1|1", "0/0"]
+
+    v.numpy_genotypes = (np.array([[-1, 1], [-1, 0]]),
+                         np.array([False, False]))
+    assert get_gt_str(v) == ["./1", "./0"]
+
+    v.numpy_genotypes = (np.array([[-1, -1], [0, 0]]),
+                         np.array([False, True]))
+    assert get_gt_str(v) == ["./.", "0|0"]
+
+    v.numpy_genotypes = (np.array([[2, 2], [0, 2]]),
+                         np.array([True, True]))
+    assert get_gt_str(v) == ["2|2", "0|2"]
+
+    v.numpy_genotypes = (np.array([[0, 1, 2], [1, 2, -2]]),
+                         np.array([False, True]))
+    assert get_gt_str(v) == ["0/1/2", "1|2"]
+
+    v.numpy_genotypes = (np.array([[1, 2, -2], [0, 1, 2]]),
+                         np.array([False, True]))
+    assert get_gt_str(v) == ["1/2", "0|1|2"]
+
+    v.numpy_genotypes = (np.array([[0, 1, 2], [0, 1, 2]]),
+                         np.array([False, True]))
+    assert get_gt_str(v) == ["0/1/2", "0|1|2"]
+    assert v.genotypes == [[0, 1, 2, False], [0, 1, 2, True]]
+
+def test_gt_caching():
+    v = next(VCF('{}/test-format-string.vcf'.format(HERE)))
+    assert v.genotypes == v.genotypes
+    assert np.all(v.numpy_genotypes[0] == v.numpy_genotypes[0])
+    assert np.all(v.numpy_genotypes[1] == v.numpy_genotypes[1])
 
 def test_info_del():
     vcf = VCF(os.path.join(HERE, "test-hemi.vcf"))
@@ -658,15 +699,27 @@ def test_access_gts():
     v = next(vcf)
     gts = v.genotypes
     assert gts == [[0, 0, False], [1, 1, True]], gts
+    ngts = v.numpy_genotypes
+    assert np.all(ngts[0] == np.array([[0, 0], [1, 1]]))
+    assert np.all(ngts[1] == np.array([False, True]))
 
     v = next(vcf)
     assert v.genotypes == [[1, 2, False], [2, 3, True]], v.genotypes
+    ngts = v.numpy_genotypes
+    assert np.all(ngts[0] == np.array([[1, 2], [2, 3]]))
+    assert np.all(ngts[1] == np.array([False, True]))
 
     v = next(vcf)
     assert v.genotypes == [[0, 1, -1, False], [0, True]], v.genotypes
+    ngts = v.numpy_genotypes
+    assert np.all(ngts[0] == np.array([[0, 1, -1], [0, -2, -2]]))
+    assert np.all(ngts[1] == np.array([False, True]))
 
     v = next(vcf)
     assert v.genotypes == [[-1, True], [0, 2, True]], v.genotypes
+    ngts = v.numpy_genotypes
+    assert np.all(ngts[0] == np.array([[-1, -2], [0, 2]]))
+    assert np.all(ngts[1] == np.array([True, True]))
 
 def test_alt_homozygous_gt():
     vcf = VCF(os.path.join(HERE, "test-multiallelic-homozygous-alt.vcf.gz"))
@@ -721,6 +774,27 @@ def test_issue44():
         #print(v.genotypes, file=sys.stderr)
         assert v.genotypes == [expected[i]], (i, v.genotypes, expected[i])
     os.unlink("__o.vcf")
+
+def test_issue44_numpy_genotypes():
+    vcf = VCF('{}/issue_44.vcf'.format(HERE))
+    w = Writer('__o.vcf', vcf)
+    for v in vcf:
+        tmp = v.numpy_genotypes
+        v.numpy_genotypes = tmp
+        w.write_record(v)
+    w.close()
+    #           "./."            "."          ".|."           "0|0"
+    expected = ((np.array([[-1, -1]]), np.array(False)),
+                (np.array([[-1]]), np.array(False)),
+                (np.array([[-1, -1]]), np.array(True)),
+                (np.array([[0, 0]]), np.array(True)))
+    for i, v in enumerate(VCF('__o.vcf')):
+        ngts = v.numpy_genotypes
+        assert np.all(ngts[0] == expected[i][0])
+        assert np.all(ngts[1] == expected[i][1]), (v.genotypes)
+    os.unlink("__o.vcf")
+
+
 
 def test_id_field_updates():
     # 1 10172   .       CCCTAA  C       92.0    PASS
@@ -782,7 +856,26 @@ def test_strict_gt_option_flag():
         [-1, 0, False],
         [-1, -1, False],
     )
-
+    truth_numpy_genotypes = (
+        np.array([[0, 0],
+                  [1, 1],
+                  [0, 1],
+                  [1, 0],
+                  [1, -1],
+                  [-1, 1],
+                  [0, -1],
+                  [-1, 0],
+                  [-1, -1]]),
+        np.array([False,
+                  False,
+                  False,
+                  False,
+                  False,
+                  False,
+                  False,
+                  False,
+                  False])
+    )
     vcf = VCF(test_vcf, gts012=False)
     variant = next(vcf)
 
@@ -791,6 +884,11 @@ def test_strict_gt_option_flag():
     assert tuple(variant.gt_bases.tolist()) == truth_gt_bases, '{} [gt_bases]'.format(msg)
     assert tuple(variant.gt_types.tolist()) == truth_gt_types, '{} [gt_types]'.format(msg)
     assert tuple(variant.genotypes) == truth_genotypes, '{} (genotypes)'.format(msg)
+    ngts = variant.numpy_genotypes
+    assert np.all(ngts[0] == truth_numpy_genotypes[0]), '{} (numpy_genotypes)'.format(msg)
+    assert np.all(ngts[1] == truth_numpy_genotypes[1]), '{} (numpy_genotypes)'.format(msg)
+
+
 
     vcf = VCF(test_vcf, gts012=False, strict_gt=True)
     variant = next(vcf)
@@ -800,8 +898,9 @@ def test_strict_gt_option_flag():
     assert tuple(variant.gt_bases.tolist()) == truth_gt_bases, '{} [gt_bases]'.format(msg)
     assert tuple(variant.gt_types.tolist()) == truth_gt_types, '{} [gt_types]'.format(msg)
     assert tuple(variant.genotypes) == truth_genotypes, '{} (genotypes)'.format(msg)
-
-
+    ngts = variant.numpy_genotypes
+    assert np.all(ngts[0] == truth_numpy_genotypes[0]), '{} (numpy_genotypes)'.format(msg)
+    assert np.all(ngts[1] == truth_numpy_genotypes[1]), '{} (numpy_genotypes)'.format(msg)
     vcf = VCF(test_vcf, gts012=True)
     variant = next(vcf)
 
@@ -812,6 +911,9 @@ def test_strict_gt_option_flag():
     #sys.stderr.write("exp:%s\n" % list(truth_gt_types))
     assert tuple(variant.gt_types.tolist()) == truth_gt_types, '{} [gt_types]'.format(msg)
     assert tuple(variant.genotypes) == truth_genotypes, '{} (genotypes)'.format(msg)
+    ngts = variant.numpy_genotypes
+    assert np.all(ngts[0] == truth_numpy_genotypes[0]), '{} (numpy_genotypes)'.format(msg)
+    assert np.all(ngts[1] == truth_numpy_genotypes[1]), '{} (numpy_genotypes)'.format(msg)
 
     vcf = VCF(test_vcf, gts012=True, strict_gt=True)
     variant = next(vcf)
@@ -821,6 +923,9 @@ def test_strict_gt_option_flag():
     assert tuple(variant.gt_bases.tolist()) == truth_gt_bases, '{} [gt_bases]'.format(msg)
     assert tuple(variant.gt_types.tolist()) == truth_gt_types, '{} [gt_types]'.format(msg)
     assert tuple(variant.genotypes) == truth_genotypes, '{} (genotypes)'.format(msg)
+    ngts = variant.numpy_genotypes
+    assert np.all(ngts[0] == truth_numpy_genotypes[0]), '{} (numpy_genotypes)'.format(msg)
+    assert np.all(ngts[1] == truth_numpy_genotypes[1]), '{} (numpy_genotypes)'.format(msg)
 
 def test_alt_repr():
     v = os.path.join(HERE, "test-alt-repr.vcf")

--- a/cyvcf2/tests/test_reader.py
+++ b/cyvcf2/tests/test_reader.py
@@ -625,47 +625,6 @@ def test_set_gts():
     
     v.genotypes = [[0, 1, 2, False], [0, 1, 2, True]]
     assert get_gt_str(v) == ["0/1/2", "0|1|2"]
-    assert np.all(v.numpy_genotypes[0] == np.array([[0, 1, 2], [0, 1, 2]]))
-    assert np.all(v.numpy_genotypes[1] == np.array([False, True]))
-
-def test_set_numpy_gts():
-    vcf = VCF('{}/test-format-string.vcf'.format(HERE))
-    v = next(vcf)
-
-    v.numpy_genotypes = (np.array([[1, 1], [0, 0]]),
-                         np.array([True, False]))
-    assert get_gt_str(v) == ["1|1", "0/0"]
-
-    v.numpy_genotypes = (np.array([[-1, 1], [-1, 0]]),
-                         np.array([False, False]))
-    assert get_gt_str(v) == ["./1", "./0"]
-
-    v.numpy_genotypes = (np.array([[-1, -1], [0, 0]]),
-                         np.array([False, True]))
-    assert get_gt_str(v) == ["./.", "0|0"]
-
-    v.numpy_genotypes = (np.array([[2, 2], [0, 2]]),
-                         np.array([True, True]))
-    assert get_gt_str(v) == ["2|2", "0|2"]
-
-    v.numpy_genotypes = (np.array([[0, 1, 2], [1, 2, -2]]),
-                         np.array([False, True]))
-    assert get_gt_str(v) == ["0/1/2", "1|2"]
-
-    v.numpy_genotypes = (np.array([[1, 2, -2], [0, 1, 2]]),
-                         np.array([False, True]))
-    assert get_gt_str(v) == ["1/2", "0|1|2"]
-
-    v.numpy_genotypes = (np.array([[0, 1, 2], [0, 1, 2]]),
-                         np.array([False, True]))
-    assert get_gt_str(v) == ["0/1/2", "0|1|2"]
-    assert v.genotypes == [[0, 1, 2, False], [0, 1, 2, True]]
-
-def test_gt_caching():
-    v = next(VCF('{}/test-format-string.vcf'.format(HERE)))
-    assert v.genotypes == v.genotypes
-    assert np.all(v.numpy_genotypes[0] == v.numpy_genotypes[0])
-    assert np.all(v.numpy_genotypes[1] == v.numpy_genotypes[1])
 
 def test_info_del():
     vcf = VCF(os.path.join(HERE, "test-hemi.vcf"))
@@ -699,27 +658,15 @@ def test_access_gts():
     v = next(vcf)
     gts = v.genotypes
     assert gts == [[0, 0, False], [1, 1, True]], gts
-    ngts = v.numpy_genotypes
-    assert np.all(ngts[0] == np.array([[0, 0], [1, 1]]))
-    assert np.all(ngts[1] == np.array([False, True]))
 
     v = next(vcf)
     assert v.genotypes == [[1, 2, False], [2, 3, True]], v.genotypes
-    ngts = v.numpy_genotypes
-    assert np.all(ngts[0] == np.array([[1, 2], [2, 3]]))
-    assert np.all(ngts[1] == np.array([False, True]))
 
     v = next(vcf)
     assert v.genotypes == [[0, 1, -1, False], [0, True]], v.genotypes
-    ngts = v.numpy_genotypes
-    assert np.all(ngts[0] == np.array([[0, 1, -1], [0, -2, -2]]))
-    assert np.all(ngts[1] == np.array([False, True]))
 
     v = next(vcf)
     assert v.genotypes == [[-1, True], [0, 2, True]], v.genotypes
-    ngts = v.numpy_genotypes
-    assert np.all(ngts[0] == np.array([[-1, -2], [0, 2]]))
-    assert np.all(ngts[1] == np.array([True, True]))
 
 def test_alt_homozygous_gt():
     vcf = VCF(os.path.join(HERE, "test-multiallelic-homozygous-alt.vcf.gz"))
@@ -774,27 +721,6 @@ def test_issue44():
         #print(v.genotypes, file=sys.stderr)
         assert v.genotypes == [expected[i]], (i, v.genotypes, expected[i])
     os.unlink("__o.vcf")
-
-def test_issue44_numpy_genotypes():
-    vcf = VCF('{}/issue_44.vcf'.format(HERE))
-    w = Writer('__o.vcf', vcf)
-    for v in vcf:
-        tmp = v.numpy_genotypes
-        v.numpy_genotypes = tmp
-        w.write_record(v)
-    w.close()
-    #           "./."            "."          ".|."           "0|0"
-    expected = ((np.array([[-1, -1]]), np.array(False)),
-                (np.array([[-1]]), np.array(False)),
-                (np.array([[-1, -1]]), np.array(True)),
-                (np.array([[0, 0]]), np.array(True)))
-    for i, v in enumerate(VCF('__o.vcf')):
-        ngts = v.numpy_genotypes
-        assert np.all(ngts[0] == expected[i][0])
-        assert np.all(ngts[1] == expected[i][1]), (v.genotypes)
-    os.unlink("__o.vcf")
-
-
 
 def test_id_field_updates():
     # 1 10172   .       CCCTAA  C       92.0    PASS
@@ -856,26 +782,7 @@ def test_strict_gt_option_flag():
         [-1, 0, False],
         [-1, -1, False],
     )
-    truth_numpy_genotypes = (
-        np.array([[0, 0],
-                  [1, 1],
-                  [0, 1],
-                  [1, 0],
-                  [1, -1],
-                  [-1, 1],
-                  [0, -1],
-                  [-1, 0],
-                  [-1, -1]]),
-        np.array([False,
-                  False,
-                  False,
-                  False,
-                  False,
-                  False,
-                  False,
-                  False,
-                  False])
-    )
+
     vcf = VCF(test_vcf, gts012=False)
     variant = next(vcf)
 
@@ -884,11 +791,6 @@ def test_strict_gt_option_flag():
     assert tuple(variant.gt_bases.tolist()) == truth_gt_bases, '{} [gt_bases]'.format(msg)
     assert tuple(variant.gt_types.tolist()) == truth_gt_types, '{} [gt_types]'.format(msg)
     assert tuple(variant.genotypes) == truth_genotypes, '{} (genotypes)'.format(msg)
-    ngts = variant.numpy_genotypes
-    assert np.all(ngts[0] == truth_numpy_genotypes[0]), '{} (numpy_genotypes)'.format(msg)
-    assert np.all(ngts[1] == truth_numpy_genotypes[1]), '{} (numpy_genotypes)'.format(msg)
-
-
 
     vcf = VCF(test_vcf, gts012=False, strict_gt=True)
     variant = next(vcf)
@@ -898,9 +800,8 @@ def test_strict_gt_option_flag():
     assert tuple(variant.gt_bases.tolist()) == truth_gt_bases, '{} [gt_bases]'.format(msg)
     assert tuple(variant.gt_types.tolist()) == truth_gt_types, '{} [gt_types]'.format(msg)
     assert tuple(variant.genotypes) == truth_genotypes, '{} (genotypes)'.format(msg)
-    ngts = variant.numpy_genotypes
-    assert np.all(ngts[0] == truth_numpy_genotypes[0]), '{} (numpy_genotypes)'.format(msg)
-    assert np.all(ngts[1] == truth_numpy_genotypes[1]), '{} (numpy_genotypes)'.format(msg)
+
+
     vcf = VCF(test_vcf, gts012=True)
     variant = next(vcf)
 
@@ -911,9 +812,6 @@ def test_strict_gt_option_flag():
     #sys.stderr.write("exp:%s\n" % list(truth_gt_types))
     assert tuple(variant.gt_types.tolist()) == truth_gt_types, '{} [gt_types]'.format(msg)
     assert tuple(variant.genotypes) == truth_genotypes, '{} (genotypes)'.format(msg)
-    ngts = variant.numpy_genotypes
-    assert np.all(ngts[0] == truth_numpy_genotypes[0]), '{} (numpy_genotypes)'.format(msg)
-    assert np.all(ngts[1] == truth_numpy_genotypes[1]), '{} (numpy_genotypes)'.format(msg)
 
     vcf = VCF(test_vcf, gts012=True, strict_gt=True)
     variant = next(vcf)
@@ -923,9 +821,6 @@ def test_strict_gt_option_flag():
     assert tuple(variant.gt_bases.tolist()) == truth_gt_bases, '{} [gt_bases]'.format(msg)
     assert tuple(variant.gt_types.tolist()) == truth_gt_types, '{} [gt_types]'.format(msg)
     assert tuple(variant.genotypes) == truth_genotypes, '{} (genotypes)'.format(msg)
-    ngts = variant.numpy_genotypes
-    assert np.all(ngts[0] == truth_numpy_genotypes[0]), '{} (numpy_genotypes)'.format(msg)
-    assert np.all(ngts[1] == truth_numpy_genotypes[1]), '{} (numpy_genotypes)'.format(msg)
 
 def test_alt_repr():
     v = os.path.join(HERE, "test-alt-repr.vcf")


### PR DESCRIPTION
Added getting and setting phased genotypes as numpy arrays using the property numpy_genotypes.

variant.numpy_genotypes returns 2 numpy arrays.  The first is a num_samples by max_ploidy int array, where each entry is an individual's allele (-1 if missing, -2 is absent [i.e. that individual has ploidy less than max_ploidy]).  The second array is a 1d bool array of size num_samples, indicating whether or not each sample is phased.

Setting is also supported given that variant.numpy_genotypes is set to be a tuple of two arrays as described above.  i.e.
variant1.numpy_genotypes = variant2.numpy_genotypes
will cause variant1 to have the same phased genotypes as variant2.

getting and setting either the numpy_genotypes or the genotypes properties will result in both being set to the correct, new value.