### PR TITLE
 add alternative genotypes array impl

### DIFF
--- a/cyvcf2/cyvcf2.pyx
+++ b/cyvcf2/cyvcf2.pyx
@@ -940,21 +940,6 @@ cdef class Genotypes(object):
         """
         return (self._raw[i * self.ploidy + 1] & 1) == 1
 
-    def phased_array(self):
-        cdef int ind
-        cdef int* to_return = <int *>stdlib.malloc(sizeof(int)
-                                                   * self.n_samples)
-        cdef np.npy_intp shape[1]
-        shape[0] = self.n_samples
-        for ind in range(self.n_samples):
-            to_return[ind] = self._raw[ind * self.ploidy + 1] & 1
-        return np.PyArray_SimpleNewFromData(
-            1,
-            shape,
-            np.NPY_INT32,
-            to_return
-        ).astype(bool)
-
     def alleles(self, int i):
         cdef list result = []
         cdef int32_t v
@@ -989,28 +974,6 @@ cdef class Genotypes(object):
             2,
             shape,
             np.NPY_INT16,
-            to_return
-        )
-
-    def alleles_array(self):
-        cdef int ind
-        cdef int allele
-        cdef int* to_return = <int *>stdlib.malloc(sizeof(int)
-                                                   * self.n_samples
-                                                   * self.ploidy)
-        cdef np.npy_intp shape[2]
-        shape[0] = self.n_samples
-        shape[1] = self.ploidy
-
-        for ind in range(self.n_samples):
-            for allele in range(self.ploidy):
-                to_return[ind*self.ploidy + allele] = (
-                    (self._raw[ind * self.ploidy + allele] >> 1) - 1
-                )
-        return np.PyArray_SimpleNewFromData(
-            2,
-            shape,
-            np.NPY_INT32,
             to_return
         )
 

--- a/cyvcf2/tests/test_reader.py
+++ b/cyvcf2/tests/test_reader.py
@@ -693,8 +693,8 @@ def test_access_genotype():
     assert alleles[1].value == 1
     assert alleles[1].phased == True
 
-    assert np.all(gts.alleles_array() == np.array([[0, 0], [1, 1]]))
-    assert np.all(gts.phased_array() == np.array([False, True]))
+    assert np.all(gts.array()[:, :2] == np.array([[0, 0], [1, 1]]))
+    assert np.all(gts.array()[:, 2] == np.array([False, True]))
 
     assert alleles[1].phased == True
     alleles[1].phased = False
@@ -702,7 +702,7 @@ def test_access_genotype():
     alleles = gts[1]
     assert alleles[1].phased == False
 
-    assert np.all(gts.phased_array() == np.array([False, False]))
+    assert np.all(gts.array()[:, 2] == np.array([False, False]))
 
     # can also just get the phased stats of the nth sample:
     assert gts.phased(0) == False
@@ -723,11 +723,11 @@ def test_access_genotype():
     assert alleles[0].value == 1
     assert alleles[0].phased == False
 
-    assert np.all(gts.alleles_array() == np.array([[1, 0], [1, 1]]))
+    assert np.all(gts.array()[:, :2] == np.array([[1, 0], [1, 1]]))
 
     gts[1][0].value = 0
 
-    assert np.all(gts.alleles_array() == np.array([[1, 0], [0, 1]]))
+    assert np.all(gts.array()[:, :2] == np.array([[1, 0], [0, 1]]))
 
     # update the varint
     v.genotype = gts


### PR DESCRIPTION
@jeffspence would you take a look.
This is a tiny bit faster. I like this because it matches the type returned from variant.genotypes, but otherwise, I'll defer to your thoughts on if you think this should replace Genotypes.allles_array and phased_array.