### PR TITLE
Removed inline keyword so it compiles on Ubuntu:18.04 Fixes issue #137

### DIFF
--- a/cyvcf2/relatedness.h
+++ b/cyvcf2/relatedness.h
@@ -7,7 +7,7 @@
 #define _UNKNOWN 3
 
 // internal calculate of alternate allele frequency.
-inline float aaf(int *gt_types, int32_t n_samples){
+float aaf(int *gt_types, int32_t n_samples){
 	float af = 0;
 	int i, n_called = 0;
 
@@ -134,7 +134,7 @@ int related(int *gt_types, double *asum, int32_t *N, int32_t *ibs0, int32_t *ibs
 }
 
 // returns 1 if this is a usable site.
-inline int ab_ok(double ab, int ab_missing) {
+int ab_ok(double ab, int ab_missing) {
     if (ab_missing) {
         return 1;
     }


### PR DESCRIPTION
Removing the inline keyword fixes the issue of the import error under Ubuntu:18.04.

See https://github.com/brentp/cyvcf2/issues/137 for information.