### PR TITLE
External htslib

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "htslib"]
-	path = htslib
-	url = https://github.com/samtools/htslib

--- a/README.md
+++ b/README.md
@@ -73,17 +73,19 @@ Installation
 pip install cyvcf2
 ```
 
-## github (building htslib and cyvcf2 from source)
+## conda
+```
+conda install -c bioconda cyvcf2
+```
 
+
+Developing
+==========
 ```
 git clone --recursive https://github.com/brentp/cyvcf2
-cd cyvcf2/htslib
-autoheader
-autoconf
-./configure --enable-libcurl
-make
+conda install -c bioconda --file requirements.txt
+cd cyvcf
 
-cd ..
 pip install -e .
 ```
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+htslib>=1.9
 cython>=0.23.3
 numpy
 coloredlogs

--- a/setup.py
+++ b/setup.py
@@ -55,20 +55,15 @@ install_requirements(missing_requirements(requires))
 
 excludes = ['irods', 'plugin']
 
-sources = [x for x in glob.glob('htslib/*.c') if not any(e in x for e in excludes)] + glob.glob('htslib/cram/*.c')
-# these have main()'s
-sources = [x for x in sources if not x.endswith(('htsfile.c', 'tabix.c', 'bgzip.c'))]
-sources.append('cyvcf2/helpers.c')
-
 import numpy as np
 import platform
 from Cython.Distutils import build_ext
 
 cmdclass = {'build_ext': build_ext}
 extension = [Extension("cyvcf2.cyvcf2",
-                        ["cyvcf2/cyvcf2.pyx"] + sources,
-                        libraries=['z', 'bz2', 'lzma', 'curl', 'ssl'] + (['crypt'] if platform.system() != 'Darwin' else []),
-                        include_dirs=['htslib', 'cyvcf2', np.get_include()])]
+                        ["cyvcf2/cyvcf2.pyx", "cyvcf2/helpers.c"],
+                        libraries=['z', 'bz2', 'lzma', 'curl', 'ssl', 'hts'] + (['crypt'] if platform.system() != 'Darwin' else []),
+                        include_dirs=['cyvcf2', np.get_include()])]
 
 
 setup(


### PR DESCRIPTION
This pull request enables the usage of external htslib versions.
Therefore, it applies [this patch from bioconda](https://github.com/bioconda/bioconda-recipes/blob/master/recipes/cyvcf2/patches/setup.py.patch) and adds instructions how to use cyvcf2 with conda.