### PR TITLE
Clarify use of Writer class

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -60,7 +60,7 @@ Modifying Existing Records
 ==========================
 
 `cyvcf2` is optimized for fast reading and extraction from existing files.
-However, it also offers some means of modifying existing VCFs. Here, wrapper
+However, it also offers some means of modifying existing VCFs. Here, we
 show an example of how to annotate variants with the genes that they overlap.
 
 
@@ -74,7 +74,8 @@ show an example of how to annotate variants with the genes that they overlap.
         'Type':'Character', 'Number': '1'})
 
     # create a new vcf Writer using the input vcf as a template.
-    w = Writer(f, vcf)
+    fname = "out.vcf"
+    w = Writer(fname, vcf)
 
     for v in vcf:
         # The get_gene_intersections function is not shown.


### PR DESCRIPTION
I found it a little ambiguous what `f` was in the input to `Writer` and had to go and look at the API docs to figure it out. This addition makes it much clearer that `f` is the name of the output VCF file to write.