### PR TITLE
Improve inference of file mode when writing

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ autoconf
 make
 
 cd ..
+pip install -r requirements.txt
 CYTHONIZE=1 pip install -e .
 ```
 

--- a/cyvcf2/cyvcf2.pyx
+++ b/cyvcf2/cyvcf2.pyx
@@ -2217,16 +2217,21 @@ cdef class Writer(VCF):
     tmpl: VCF
         a template to use to create the output header.
     mode: str
-        Mode to use for writing the file. If `None` (default) is given, the mode is
-        inferred from the filename extension. If stdout ("-") is provided for `fname`
-        and `mode` is left at default, uncompressed VCF will be produced.
-        Valid values are:
-          - "wbu": uncompressed BCF
-          - "wb": compressed BCF
-          - "wz": compressed VCF
-          - "w": uncompressed VCF
-        Compression level can also be indicated by adding a single integer to one of
-        the compressed modes (e.g. "wz4" for VCF with compressions level 4).
+        | Mode to use for writing the file. If ``None`` (default) is given, the mode is
+          inferred from the filename extension. If stdout (``"-"``) is provided for ``fname``
+          and ``mode`` is left at default, uncompressed VCF will be produced.
+        | Valid values are:
+        |  - ``"wbu"``: uncompressed BCF
+        |  - ``"wb"``: compressed BCF
+        |  - ``"wz"``: compressed VCF
+        |  - ``"w"``: uncompressed VCF
+        | Compression level can also be indicated by adding a single integer to one of
+          the compressed modes (e.g. ``"wz4"`` for VCF with compressions level 4).
+
+    Note
+    ----
+    File extensions ``.bcf`` and ``.bcf.gz`` will both return compressed BCF. If you
+    want uncompressed BCF you must explicitly provide the appropriate ``mode``.
 
     Returns
     -------
@@ -2262,10 +2267,10 @@ cdef class Writer(VCF):
         file_fmt = fname.split(".")[fmt_idx]
         # bcftools output write mode chars - https://github.com/samtools/bcftools/blob/76392b3014de70b7fa5c6b5c9d5bc47361951770/version.c#L64-L70
         inferred_mode = "w"
-        if file_fmt == "bcf" and not is_compressed:
-            inferred_mode += "bu"
-        if is_compressed:
-            inferred_mode += "z" if file_fmt == "vcf" else "b"
+        if file_fmt == "bcf":
+            inferred_mode += "b"
+        if is_compressed and file_fmt == "vcf":
+            inferred_mode += "z"
 
         return inferred_mode
 

--- a/cyvcf2/cyvcf2.pyx
+++ b/cyvcf2/cyvcf2.pyx
@@ -1918,7 +1918,7 @@ cdef class Variant(object):
     property FILTER:
         """the value of FILTER from the VCF field.
 
-        a value of PASS in the VCF will give None for this function
+        a value of PASS or '.' in the VCF will give None for this function
         """
         def __get__(self):
             cdef int i

--- a/cyvcf2/cyvcf2.pyx
+++ b/cyvcf2/cyvcf2.pyx
@@ -173,7 +173,7 @@ cdef class HTSFile:
                     inferred_mode += "bu"
                 if is_compressed:
                     inferred_mode += "z" if file_fmt == b"vcf" else "b"
-                sys.stderr.write(inferred_mode + "\n")
+                    
                 self.mode = to_bytes(inferred_mode)
 
             self.hts = hts_open(self.fname, self.mode)

--- a/cyvcf2/cyvcf2.pyx
+++ b/cyvcf2/cyvcf2.pyx
@@ -163,23 +163,10 @@ cdef class HTSFile:
             self.fname = to_bytes(str(fname))
             if self.fname == b"-":
                 self.fname = to_bytes(b"/dev/stdin") if reading else to_bytes(b"/dev/stdout")
-            if writing:
-                is_compressed = self.fname.endswith(b".gz")
-                fmt_idx = -2 if is_compressed else -1
-                file_fmt = self.fname.split(b".")[fmt_idx]
-                # bcftools output write mode chars - https://github.com/samtools/bcftools/blob/76392b3014de70b7fa5c6b5c9d5bc47361951770/version.c#L64-L70
-                inferred_mode = "w"
-                if file_fmt == b"bcf" and not is_compressed:
-                    inferred_mode += "bu"
-                if is_compressed:
-                    inferred_mode += "z" if file_fmt == b"vcf" else "b"
-                    
-                self.mode = to_bytes(inferred_mode)
 
             self.hts = hts_open(self.fname, self.mode)
         # from a file descriptor
         elif isinstance(fname, int):
-            self.mode = to_bytes(mode)
             hf = hdopen(int(fname), self.mode)
             self.hts = hts_hopen(hf, "<file>", self.mode)
             self.fname = None
@@ -187,7 +174,6 @@ cdef class HTSFile:
         elif hasattr(fname, "fileno"):
             if fname.closed:
                 raise IOError('I/O operation on closed file')
-            self.mode = to_bytes(mode)
             hf = hdopen(fname.fileno(), self.mode)
             self.hts = hts_hopen(hf, "<file>", self.mode)
             # .name can be TextIOWrapper
@@ -2231,13 +2217,16 @@ cdef class Writer(VCF):
     tmpl: VCF
         a template to use to create the output header.
     mode: str
-        Mode to use for writing the file. This parameter is only relevant if writing to
-        stdout. If writing to a file, the mode is inferred from the filename extension.
+        Mode to use for writing the file. If `None` (default) is given, the mode is
+        inferred from the filename extension. If stdout ("-") is provided for `fname`
+        and `mode` is left at default, uncompressed VCF will be produced.
         Valid values are:
           - "wbu": uncompressed BCF
           - "wb": compressed BCF
           - "wz": compressed VCF
           - "w": uncompressed VCF
+        Compression level can also be indicated by adding a single integer to one of
+        the compressed modes (e.g. "wz4" for VCF with compressions level 4).
 
     Returns
     -------
@@ -2249,13 +2238,36 @@ cdef class Writer(VCF):
     cdef bint header_written
     cdef const bcf_hdr_t *ohdr
 
-    def __init__(Writer self, fname, VCF tmpl, mode="w"):
+    def __init__(Writer self, fname, VCF tmpl, mode=None):
+        mode = self._infer_file_mode(fname, mode)
         self._open_htsfile(fname, mode)
         bcf_hdr_sync(tmpl.hdr)
         self.ohdr = tmpl.hdr
         self.hdr = bcf_hdr_dup(tmpl.hdr)
         bcf_hdr_sync(self.hdr)
         self.header_written = False
+
+    @staticmethod
+    def _infer_file_mode(fname, mode=None):
+        if mode is not None:
+            return mode
+
+        from_path = isinstance(fname, (basestring, Path))
+        if not from_path:
+            return "w"
+
+        fname = str(fname)
+        is_compressed = fname.endswith(".gz")
+        fmt_idx = -2 if is_compressed else -1
+        file_fmt = fname.split(".")[fmt_idx]
+        # bcftools output write mode chars - https://github.com/samtools/bcftools/blob/76392b3014de70b7fa5c6b5c9d5bc47361951770/version.c#L64-L70
+        inferred_mode = "w"
+        if file_fmt == "bcf" and not is_compressed:
+            inferred_mode += "bu"
+        if is_compressed:
+            inferred_mode += "z" if file_fmt == "vcf" else "b"
+
+        return inferred_mode
 
     @classmethod
     def from_string(Writer cls, fname, header_string, mode="w"):

--- a/cyvcf2/tests/test_writer.py
+++ b/cyvcf2/tests/test_writer.py
@@ -1,0 +1,100 @@
+from io import StringIO
+
+from cyvcf2 import Writer
+
+try:
+    from pathlib import Path
+except ImportError:
+    from pathlib2 import Path  # python 2 backport
+
+
+class TestFileModeInference:
+    def test_defaultModeWithVcfFname_returnsUncompressedVcf(self):
+        fname = "test.vcf"
+        mode = None
+
+        actual = Writer._infer_file_mode(fname, mode)
+        expected = "w"
+
+        assert actual == expected
+
+    def test_defaultModeWithBcfFname_returnsUncompressedBcf(self):
+        fname = "test.bcf"
+        mode = None
+
+        actual = Writer._infer_file_mode(fname, mode)
+        expected = "wbu"
+
+        assert actual == expected
+
+    def test_defaultModeWithCompressedBcfFname_returnsCompressedBcf(self):
+        fname = "test.bcf.gz"
+        mode = None
+
+        actual = Writer._infer_file_mode(fname, mode)
+        expected = "wb"
+
+        assert actual == expected
+
+    def test_defaultModeWithCompressedVcfFname_returnsCompressedVcf(self):
+        fname = "test.vcf.gz"
+        mode = None
+
+        actual = Writer._infer_file_mode(fname, mode)
+        expected = "wz"
+
+        assert actual == expected
+
+    def test_defaultModeWithStdOut_returnsUncompressedVcf(self):
+        fname = "-"
+        mode = None
+
+        actual = Writer._infer_file_mode(fname, mode)
+        expected = "w"
+
+        assert actual == expected
+
+    def test_defaultModeWithNonVcfName_returnsUncompressedVcf(self):
+        fname = "foo"
+        mode = None
+
+        actual = Writer._infer_file_mode(fname, mode)
+        expected = "w"
+
+        assert actual == expected
+
+    def test_defaultModeWithIntFname_returnsUncompressedVcf(self):
+        fname = 1
+        mode = None
+
+        actual = Writer._infer_file_mode(fname, mode)
+        expected = "w"
+
+        assert actual == expected
+
+    def test_defaultModeWithHandle_returnsUncompressedVcf(self):
+        fname = StringIO()
+        mode = None
+
+        actual = Writer._infer_file_mode(fname, mode)
+        expected = "w"
+
+        assert actual == expected
+
+    def test_defaultModeWithPosixPath_returnsUncompressedVcf(self):
+        fname = Path("test.vcf")
+        mode = None
+
+        actual = Writer._infer_file_mode(fname, mode)
+        expected = "w"
+
+        assert actual == expected
+
+    def test_explicitMode_doesNotInferFromFname(self):
+        fname = "test.vcf.gz"
+        mode = "wb4"
+
+        actual = Writer._infer_file_mode(fname, mode)
+        expected = "wb4"
+
+        assert actual == expected

--- a/cyvcf2/tests/test_writer.py
+++ b/cyvcf2/tests/test_writer.py
@@ -18,12 +18,21 @@ class TestFileModeInference:
 
         assert actual == expected
 
-    def test_defaultModeWithBcfFname_returnsUncompressedBcf(self):
+    def test_defaultModeWithBcfFname_returnsCompressedBcf(self):
         fname = "test.bcf"
         mode = None
 
         actual = Writer._infer_file_mode(fname, mode)
-        expected = "wbu"
+        expected = "wb"
+
+        assert actual == expected
+
+    def test_defaultModeWithBcfFnameAndUncompressedMode_returnsUncompressedBcf(self):
+        fname = "test.bcf"
+        mode = "wbu"
+
+        actual = Writer._infer_file_mode(fname, mode)
+        expected = mode
 
         assert actual == expected
 


### PR DESCRIPTION
The current method for inferring the file mode has a few issues where the correct mode gets overwritten.

https://github.com/brentp/cyvcf2/blob/d46fdcca8a3cb08b2ed4097199cb4632790c581f/cyvcf2/cyvcf2.pyx#L168-L173

in this situation, if the filename is `out.bcf.gz` then the first branch of the `if` statement is taken and the mode is `"wz"` which is compressed VCF. Additionally, if the filename is `out.bcf`, then the mode is `"wb"` which is *compressed* BCF - uncompressed BCF is `"wbu"` <sup>[1]</sup>. BUT, because of line 173, all of these settings are undone anyway, and the original `mode` passed into the function is used, which by default is `"w"`.   
**So in the end, regardless of the filename given, uncompressed VCF is written.**

---

This PR aims to improve the logic used for inferring the write mode from a filename. I have tested it locally for all 4 possible modes and according to [`htsfile`][2] it works as expected.

In addition:
-  I have updated the docstring for `Writer` to be explicit about what `mode` options are.
- Added a line to install requirements when building locally
- Clarified the FILTER "pass" possibilities

[1]: https://github.com/samtools/bcftools/blob/76392b3014de70b7fa5c6b5c9d5bc47361951770/version.c#L64-L70
[2]: https://www.htslib.org/doc/htsfile.html