### PR TITLE
Propagate variant parse failures

### DIFF
--- a/cyvcf2/cyvcf2.pyx
+++ b/cyvcf2/cyvcf2.pyx
@@ -574,7 +574,11 @@ cdef class VCF(HTSFile):
             return newVariant(b, self)
         else:
             bcf_destroy(b)
+        if  ret == -1:  # end-of-file
+            raise StopIteration
+        else:  
             raise Exception("error parsing variant with `htslib::bcf_read` error-code: %d" % (b->err))
+
 
     property samples:
         "list of samples pulled from the VCF."

--- a/cyvcf2/cyvcf2.pyx
+++ b/cyvcf2/cyvcf2.pyx
@@ -570,14 +570,14 @@ cdef class VCF(HTSFile):
         with nogil:
             b = bcf_init()
             ret = bcf_read(self.hts, self.hdr, b)
-        if ret >= 0 or b->error == BCF_ERR_CTG_UNDEF:
+        if ret >= 0 or b.error == BCF_ERR_CTG_UNDEF:
             return newVariant(b, self)
         else:
             bcf_destroy(b)
         if  ret == -1:  # end-of-file
             raise StopIteration
         else:  
-            raise Exception("error parsing variant with `htslib::bcf_read` error-code: %d" % (b->err))
+            raise Exception("error parsing variant with `htslib::bcf_read` error-code: %d" % (b.ferr))
 
 
     property samples:

--- a/cyvcf2/cyvcf2.pyx
+++ b/cyvcf2/cyvcf2.pyx
@@ -577,7 +577,7 @@ cdef class VCF(HTSFile):
         if  ret == -1:  # end-of-file
             raise StopIteration
         else:  
-            raise Exception("error parsing variant with `htslib::bcf_read` error-code: %d" % (b.ferr))
+            raise Exception("error parsing variant with `htslib::bcf_read` error-code: %d" % (b.err))
 
 
     property samples:

--- a/cyvcf2/cyvcf2.pyx
+++ b/cyvcf2/cyvcf2.pyx
@@ -577,7 +577,7 @@ cdef class VCF(HTSFile):
         if  ret == -1:  # end-of-file
             raise StopIteration
         else:  
-            raise Exception("error parsing variant with `htslib::bcf_read` error-code: %d" % (b.err))
+            raise Exception("error parsing variant with `htslib::bcf_read` error-code: %d" % (b.error))
 
 
     property samples:

--- a/cyvcf2/cyvcf2.pyx
+++ b/cyvcf2/cyvcf2.pyx
@@ -570,11 +570,11 @@ cdef class VCF(HTSFile):
         with nogil:
             b = bcf_init()
             ret = bcf_read(self.hts, self.hdr, b)
-        if ret >= 0:
+        if ret >= 0 || b->error == BCF_ERR_CTG_UNDEF:
             return newVariant(b, self)
         else:
             bcf_destroy(b)
-        raise StopIteration
+            raise Exception("error parsing variant with `htslib::bcf_read` error-code: %d" % (b->err))
 
     property samples:
         "list of samples pulled from the VCF."

--- a/cyvcf2/cyvcf2.pyx
+++ b/cyvcf2/cyvcf2.pyx
@@ -570,7 +570,7 @@ cdef class VCF(HTSFile):
         with nogil:
             b = bcf_init()
             ret = bcf_read(self.hts, self.hdr, b)
-        if ret >= 0 || b->error == BCF_ERR_CTG_UNDEF:
+        if ret >= 0 or b->error == BCF_ERR_CTG_UNDEF:
             return newVariant(b, self)
         else:
             bcf_destroy(b)

--- a/cyvcf2/cyvcf2.pyx
+++ b/cyvcf2/cyvcf2.pyx
@@ -570,14 +570,14 @@ cdef class VCF(HTSFile):
         with nogil:
             b = bcf_init()
             ret = bcf_read(self.hts, self.hdr, b)
-        if ret >= 0 or b.error == BCF_ERR_CTG_UNDEF:
+        if ret >= 0 or b.errcode == BCF_ERR_CTG_UNDEF:
             return newVariant(b, self)
         else:
             bcf_destroy(b)
         if  ret == -1:  # end-of-file
             raise StopIteration
         else:  
-            raise Exception("error parsing variant with `htslib::bcf_read` error-code: %d" % (b.error))
+            raise Exception("error parsing variant with `htslib::bcf_read` error-code: %d" % (b.errcode))
 
 
     property samples:


### PR DESCRIPTION
Previously iteration would silently stop.

https://github.com/brentp/cyvcf2/issues/161