### PR TITLE
Add documentation on how to modify format fields and genotypes

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ cyvcf2
 Note: cyvcf2 versions < 0.20.0 require htslib < 1.10. cyvcf2 versions >= 0.20.0 require htslib >= 1.10
 
 <!-- ghp-import -p docs/build/html/ -->
+The latest documentation for cyvcf2 can be found here:
 [![Docs](https://img.shields.io/badge/docs-latest-blue.svg)](http://brentp.github.io/cyvcf2/)
 
 If you use cyvcf2, please cite the [paper](https://academic.oup.com/bioinformatics/article/2971439/cyvcf2)

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ Note: cyvcf2 versions < 0.20.0 require htslib < 1.10. cyvcf2 versions >= 0.20.0 
 
 <!-- ghp-import -p docs/build/html/ -->
 The latest documentation for cyvcf2 can be found here:
+
 [![Docs](https://img.shields.io/badge/docs-latest-blue.svg)](http://brentp.github.io/cyvcf2/)
 
 If you use cyvcf2, please cite the [paper](https://academic.oup.com/bioinformatics/article/2971439/cyvcf2)

--- a/cyvcf2/cyvcf2.pyx
+++ b/cyvcf2/cyvcf2.pyx
@@ -1440,13 +1440,13 @@ cdef class Variant(object):
         elif np.issubdtype(data.dtype, np.bytes_):
             # can pass byte array without any type conversion
             size = data.nbytes
-            bytesp = <char *> data
-            ret = bcf_update_format(self.vcf.hdr, self.b, to_bytes(name), bytesp, size, BCF_HT_STR.cint)
+            bytesp = <char *> data.data
+            ret = bcf_update_format(self.vcf.hdr, self.b, to_bytes(name), bytesp, size, BCF_HT_STR)
         elif np.issubdtype(data.dtype, np.unicode_):
             abytes = np.char.encode(data)
             size = abytes.nbytes
-            bytesp = <char *> abytes
-            ret = bcf_update_format(self.vcf.hdr, self.b, to_bytes(name), bytesp, size, BCF_HT_STR.cint)
+            bytesp = <char *> abytes.data
+            ret = bcf_update_format(self.vcf.hdr, self.b, to_bytes(name), bytesp, size, BCF_HT_STR)
         else:
             raise Exception("format: currently only float, int and string (fixed length np.bytes_ or np.unicode_) numpy arrays are supported. got %s", data.dtype)
         if ret < 0:

--- a/cyvcf2/cyvcf2.pyx
+++ b/cyvcf2/cyvcf2.pyx
@@ -1420,7 +1420,6 @@ cdef class Variant(object):
 
         cdef np.ndarray[np.float32_t, mode="c"] afloat
         cdef np.ndarray[np.int32_t, mode="c"] aint
-        cdef np.ndarray abytes
         cdef char *bytesp
 
         cdef int size
@@ -1438,17 +1437,11 @@ cdef class Variant(object):
             afloat = data.astype(np.float32).reshape((size,))
             ret = bcf_update_format_float(self.vcf.hdr, self.b, to_bytes(name), &afloat[0], size)
         elif np.issubdtype(data.dtype, np.bytes_):
-            # can pass byte array without any type conversion
             size = data.nbytes
             bytesp = <char *> data.data
             ret = bcf_update_format(self.vcf.hdr, self.b, to_bytes(name), bytesp, size, BCF_HT_STR)
-        elif np.issubdtype(data.dtype, np.unicode_):
-            abytes = np.char.encode(data)
-            size = abytes.nbytes
-            bytesp = <char *> abytes.data
-            ret = bcf_update_format(self.vcf.hdr, self.b, to_bytes(name), bytesp, size, BCF_HT_STR)
         else:
-            raise Exception("format: currently only float, int and string (fixed length np.bytes_ or np.unicode_) numpy arrays are supported. got %s", data.dtype)
+            raise Exception("format: currently only float, int and string (fixed length ASCII np.bytes_) numpy arrays are supported. got %s", data.dtype)
         if ret < 0:
             raise Exception("error (%d) setting format with: %s" % (ret, data[:100]))
 

--- a/cyvcf2/cyvcf2.pyx
+++ b/cyvcf2/cyvcf2.pyx
@@ -1420,7 +1420,7 @@ cdef class Variant(object):
 
         cdef np.ndarray[np.float32_t, mode="c"] afloat
         cdef np.ndarray[np.int32_t, mode="c"] aint
-        cdef char *bytesp
+        cdef char **bytesp
 
         cdef int size
         cdef int ret
@@ -1438,7 +1438,7 @@ cdef class Variant(object):
             ret = bcf_update_format_float(self.vcf.hdr, self.b, to_bytes(name), &afloat[0], size)
         elif np.issubdtype(data.dtype, np.bytes_):
             size = data.nbytes
-            bytesp = <char *> data.data
+            bytesp = <char **> data.data
             ret = bcf_update_format_char(self.vcf.hdr, self.b, to_bytes(name), bytesp, size)
         else:
             raise Exception("format: currently only float, int and string (fixed length ASCII np.bytes_) numpy arrays are supported. got %s", data.dtype)

--- a/cyvcf2/cyvcf2.pyx
+++ b/cyvcf2/cyvcf2.pyx
@@ -1439,7 +1439,7 @@ cdef class Variant(object):
         elif np.issubdtype(data.dtype, np.bytes_):
             size = data.nbytes
             bytesp = <char *> data.data
-            ret = bcf_update_format(self.vcf.hdr, self.b, to_bytes(name), bytesp, size, BCF_HT_STR)
+            ret = bcf_update_format_char(self.vcf.hdr, self.b, to_bytes(name), bytesp, size)
         else:
             raise Exception("format: currently only float, int and string (fixed length ASCII np.bytes_) numpy arrays are supported. got %s", data.dtype)
         if ret < 0:

--- a/cyvcf2/cyvcf2.pyx
+++ b/cyvcf2/cyvcf2.pyx
@@ -1437,7 +1437,7 @@ cdef class Variant(object):
             afloat = data.astype(np.float32).reshape((size,))
             ret = bcf_update_format_float(self.vcf.hdr, self.b, to_bytes(name), &afloat[0], size)
         elif np.issubdtype(data.dtype, np.bytes_):
-            if len(<object>data).shape > 1:
+            if len((<object>data).shape) > 1:
                 raise Exception("Setting string type format fields with number>1 are currently not supported")
             if not data.flags['C_CONTIGUOUS']:
                 data = np.ascontiguousarray(data)

--- a/cyvcf2/tests/test_reader.py
+++ b/cyvcf2/tests/test_reader.py
@@ -673,33 +673,13 @@ def test_set_format_str_bytes_first_longer():
     v.set_format("STR", np.array([b'foobar', b'baz']))
     assert np.all(v.format('STR') == np.array(['foobar', 'baz']))
 
-def test_set_format_str_unicode_second_longer():
-    vcf = VCF('{}/test-format-string.vcf'.format(HERE))
-    assert vcf.add_format_to_header(dict(ID="STR", Number=1, Type="String", Description="String example")) == 0
-    v = next(vcf)
-
-    # lower case delta
-    contents = np.array(['foo', '\u03B4'*12])
-    v.set_format("STR", contents)
-    assert np.all(v.format('STR') == contents)
-
-def test_set_format_str_unicode_first_longer():
-    vcf = VCF('{}/test-format-string.vcf'.format(HERE))
-    assert vcf.add_format_to_header(dict(ID="STR", Number=1, Type="String", Description="String example")) == 0
-    v = next(vcf)
-
-    # lower case delta
-    contents = np.array(['\u03B4'*12, 'foo'])
-    v.set_format("STR", contents)
-    assert np.all(v.format('STR') == contents)
-
-def test_set_format_str_unicode_number3():
+def test_set_format_str_bytes_number3():
     vcf = VCF('{}/test-format-string.vcf'.format(HERE))
     assert vcf.add_format_to_header(dict(ID="STR", Number=3, Type="String", Description="String example")) == 0
     v = next(vcf)
 
     # lower case delta
-    contents = np.array([['foo', 'barbaz', 'biz'], ['blub', 'bloop' + '\u03B4'*12, 'blop']])
+    contents = np.array([[b'foo', b'barbaz', b'biz'], [b'blub', b'bloop', b'blop']])
     v.set_format("STR", contents)
     assert np.all(v.format('STR') == contents)
 

--- a/cyvcf2/tests/test_reader.py
+++ b/cyvcf2/tests/test_reader.py
@@ -674,26 +674,13 @@ def test_set_format_str_bytes_first_longer():
     assert np.all(v.format('STR') == np.array(['foobar', 'baz']))
 
 def test_set_format_str_bytes_number3():
+    # Confirm currently not supported
     vcf = VCF('{}/test-format-string.vcf'.format(HERE))
     assert vcf.add_format_to_header(dict(ID="STR", Number=3, Type="String", Description="String example")) == 0
     v = next(vcf)
 
     contents = np.array([[b'foo', b'barbaz', b'biz'], [b'blub', b'bloop', b'blop']])
-    v.set_format("STR", contents)
-    print('contents', contents)
-    print('stored data', v.format('STR'))
-    assert np.all(v.format('STR') == contents)
-
-def test_set_format_str_bytes_notccontiguougs():
-    vcf = VCF('{}/test-format-string.vcf'.format(HERE))
-    assert vcf.add_format_to_header(dict(ID="STR", Number=3, Type="String", Description="String example")) == 0
-    v = next(vcf)
-
-    contents = np.array([[b'foo', b'barbaz', b'biz'], [b'blub', b'bloop', b'blop']])
-    v.set_format("STR", np.asfortranarray(contents))
-    print('contents', contents)
-    print('stored data', v.format('STR'))
-    assert np.all(v.format('STR') == contents)
+    assert_raises(Exception, v.set_format, "STR", contents)
 
 def test_set_gts():
     vcf = VCF('{}/test-format-string.vcf'.format(HERE))

--- a/cyvcf2/tests/test_reader.py
+++ b/cyvcf2/tests/test_reader.py
@@ -678,9 +678,10 @@ def test_set_format_str_bytes_number3():
     assert vcf.add_format_to_header(dict(ID="STR", Number=3, Type="String", Description="String example")) == 0
     v = next(vcf)
 
-    # lower case delta
     contents = np.array([[b'foo', b'barbaz', b'biz'], [b'blub', b'bloop', b'blop']])
     v.set_format("STR", contents)
+    print('contents', contents)
+    print('stored data', v.format('STR'))
     assert np.all(v.format('STR') == contents)
 
 def test_set_gts():

--- a/cyvcf2/tests/test_reader.py
+++ b/cyvcf2/tests/test_reader.py
@@ -684,6 +684,17 @@ def test_set_format_str_bytes_number3():
     print('stored data', v.format('STR'))
     assert np.all(v.format('STR') == contents)
 
+def test_set_format_str_bytes_notccontiguougs():
+    vcf = VCF('{}/test-format-string.vcf'.format(HERE))
+    assert vcf.add_format_to_header(dict(ID="STR", Number=3, Type="String", Description="String example")) == 0
+    v = next(vcf)
+
+    contents = np.array([[b'foo', b'barbaz', b'biz'], [b'blub', b'bloop', b'blop']])
+    v.set_format("STR", np.asfortranarray(contents))
+    print('contents', contents)
+    print('stored data', v.format('STR'))
+    assert np.all(v.format('STR') == contents)
+
 def test_set_gts():
     vcf = VCF('{}/test-format-string.vcf'.format(HERE))
     v = next(vcf)

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -61,8 +61,8 @@ Modifying Existing Records
 
 `cyvcf2` is optimized for fast reading and extraction from existing files.
 However, it also offers some means of modifying existing VCFs. Here, we
-show an example of how to annotate variants with the genes that they overlap.
-
+show an example of how to modify the INFO field at a locus to annotate
+variants with the genes that they overlap.
 
 .. code-block:: python
 
@@ -84,6 +84,51 @@ show an example of how to annotate variants with the genes that they overlap.
         genes = get_gene_intersections(v)
         if genes is not None:
             v.INFO["gene"] = ",".join(genes)
+        w.write_record(v)
+
+    w.close(); vcf.close()
+
+Here is an example where we filter some calls from records in a VCF. This demonstrates
+how to add to the FORMAT field and how to modify genotypes at a locus.
+
+.. code-block:: python
+
+    from cyvcf2 import VCF, Writer
+    vcf = VCF(VCF_PATH)
+    # adjust the header to contain the new field
+    # the keys 'ID', 'Description', 'Type', and 'Number' are required.
+    vcf.add_format_to_header({
+        'ID': 'FILTER_CODE',
+        'Description': 'Numeric code for filtering reason',
+        'Type': 'Integer',
+        'Number': '1'
+    })
+
+    # create a new vcf Writer using the input vcf as a template.
+    fname = "out.vcf"
+    w = Writer(fname, vcf)
+
+    for v in vcf:
+        # The filter_samples function is not shown.
+        # This could be any manipulation required by the user.
+        # Since we specified the FILTER_CODE format field is an Integer
+        # with Number=1, reasons must be an n x 1 numpy array of integers
+        # where n is the number of samples.
+        indicies, reasons = filter_samples(v)
+        if indicies:
+            # add the reasons array to the format dictionary at this locus
+            v.set_format('FILTER_CODE', reasons)
+            for index in indicies:
+                # overwrite the genotypes of each filtered locus to be nocalls
+                # Note: until the reassignment to v.genotypes below, this
+                # leaves the v Variant object in an inconsistent state
+                v.genotypes[index] = [-1]*v.ploidy + [False]
+            # it is necessary to reassign the genotypes field
+            # so that the v Variant object reprocess it and future calls
+            # to functions like v.genotype.array() properly reflect
+            # the changed genotypes
+            v.genotypes = v.genotypes
+
         w.write_record(v)
 
     w.close(); vcf.close()

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -180,7 +180,8 @@ Tests can be run with:
 
 Known Limitations
 =================
-`cyvcf2` currently does not support reading VCFs encoded with UTF-8 with non-ASCII characters in the contents of string-typed FORMAT fields.
+* `cyvcf2` currently does not support reading or writing VCFs encoded with UTF-8 with non-ASCII characters in the contents of string-typed FORMAT fields.
+* `cyvcf2` currently does not support writing string type format fields with number>1.
 
 See Also
 ========

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -178,6 +178,10 @@ Tests can be run with:
 
     python setup.py test
 
+Known Limitations
+=================
+`cyvcf2` currently does not support reading VCFs encoded with UTF-8 with non-ASCII characters in the contents of string-typed FORMAT fields.
+
 See Also
 ========
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -59,6 +59,8 @@ See the :ref:`api` for detailed documentation, but the most common usage is summ
 Modifying Existing Records
 ==========================
 
+.. this example is also in the writing.rst page
+
 `cyvcf2` is optimized for fast reading and extraction from existing files.
 However, it also offers some means of modifying existing VCFs. Here, we
 show an example of how to modify the INFO field at a locus to annotate
@@ -88,50 +90,7 @@ variants with the genes that they overlap.
 
     w.close(); vcf.close()
 
-Here is an example where we filter some calls from records in a VCF. This demonstrates
-how to add to the FORMAT field and how to modify genotypes at a locus.
-
-.. code-block:: python
-
-    from cyvcf2 import VCF, Writer
-    vcf = VCF(VCF_PATH)
-    # adjust the header to contain the new field
-    # the keys 'ID', 'Description', 'Type', and 'Number' are required.
-    vcf.add_format_to_header({
-        'ID': 'FILTER_CODE',
-        'Description': 'Numeric code for filtering reason',
-        'Type': 'Integer',
-        'Number': '1'
-    })
-
-    # create a new vcf Writer using the input vcf as a template.
-    fname = "out.vcf"
-    w = Writer(fname, vcf)
-
-    for v in vcf:
-        # The filter_samples function is not shown.
-        # This could be any manipulation required by the user.
-        # Since we specified the FILTER_CODE format field is an Integer
-        # with Number=1, reasons must be an n x 1 numpy array of integers
-        # where n is the number of samples.
-        indicies, reasons = filter_samples(v)
-        if indicies:
-            # add the reasons array to the format dictionary at this locus
-            v.set_format('FILTER_CODE', reasons)
-            for index in indicies:
-                # overwrite the genotypes of each filtered locus to be nocalls
-                # Note: until the reassignment to v.genotypes below, this
-                # leaves the v Variant object in an inconsistent state
-                v.genotypes[index] = [-1]*v.ploidy + [False]
-            # it is necessary to reassign the genotypes field
-            # so that the v Variant object reprocess it and future calls
-            # to functions like v.genotype.array() properly reflect
-            # the changed genotypes
-            v.genotypes = v.genotypes
-
-        w.write_record(v)
-
-    w.close(); vcf.close()
+More info on writing vcfs can be found :doc:`here <writing>`
 
 Setting Genotyping Strictness
 =============================
@@ -180,16 +139,18 @@ Tests can be run with:
 
 Known Limitations
 =================
-* `cyvcf2` currently does not support reading or writing VCFs encoded with UTF-8 with non-ASCII characters in the contents of string-typed FORMAT fields.
-* `cyvcf2` currently does not support writing string type format fields with number>1.
+* `cyvcf2` currently does not support reading VCFs encoded with UTF-8 with non-ASCII characters in the contents of string-typed FORMAT fields.
+
+For limitations on writing VCFs, see :ref:`here <Limitations with writing>`
 
 See Also
 ========
 
-Pysam also [has a cython wrapper to htslib](https://github.com/pysam-developers/pysam/blob/master/pysam/cbcf.pyx) and one block of code here is taken directly from that library. But, the optimizations that we want for gemini are very specific so we have chosen to create a separate project.
+Pysam also `has a cython wrapper to htslib <https://github.com/pysam-developers/pysam/blob/master/pysam/cbcf.pyx>`_ and one block of code here is taken directly from that library. But, the optimizations that we want for gemini are very specific so we have chosen to create a separate project.
 
 .. toctree::
-   :maxdepth: 2
+   :maxdepth: 1
 
    docstrings
+   writing
 

--- a/docs/source/writing.rst
+++ b/docs/source/writing.rst
@@ -1,0 +1,93 @@
+Modifying Existing VCFs
+=======================
+
+`cyvcf2` is optimized for fast reading and extraction from existing files.
+However, it also offers some means of modifying existing VCFs.
+
+Modifying the INFO field
+------------------------
+
+.. this is the same example as on the index.rst page
+
+Here, we show an example of how to modify the INFO field at a locus to annotate
+variants with the genes that they overlap.
+
+.. code-block:: python
+
+    from cyvcf2 import VCF, Writer
+    vcf = VCF(VCF_PATH)
+    # adjust the header to contain the new field
+    # the keys 'ID', 'Description', 'Type', and 'Number' are required.
+    vcf.add_info_to_header({'ID': 'gene', 'Description': 'overlapping gene',
+        'Type':'Character', 'Number': '1'})
+
+    # create a new vcf Writer using the input vcf as a template.
+    fname = "out.vcf"
+    w = Writer(fname, vcf)
+
+    for v in vcf:
+        # The get_gene_intersections function is not shown.
+        # This could be any operation to find intersections
+        # or any manipulation required by the user.
+        genes = get_gene_intersections(v)
+        if genes is not None:
+            v.INFO["gene"] = ",".join(genes)
+        w.write_record(v)
+
+    w.close(); vcf.close()
+
+Modifying genotypes and the FORMAT field
+----------------------------------------
+
+Here is an example where we filter some calls from records in a VCF. This demonstrates
+how to add to the FORMAT field and how to modify genotypes at a locus.
+
+.. code-block:: python
+
+    from cyvcf2 import VCF, Writer
+    vcf = VCF(VCF_PATH)
+    # adjust the header to contain the new field
+    # the keys 'ID', 'Description', 'Type', and 'Number' are required.
+    vcf.add_format_to_header({
+        'ID': 'FILTER_CODE',
+        'Description': 'Numeric code for filtering reason',
+        'Type': 'Integer',
+        'Number': '1'
+    })
+
+    # create a new vcf Writer using the input vcf as a template.
+    fname = "out.vcf"
+    w = Writer(fname, vcf)
+
+    for v in vcf:
+        # The filter_samples function is not shown.
+        # This could be any manipulation required by the user.
+        # Since we specified the FILTER_CODE format field is an Integer
+        # with Number=1, reasons must be an n x 1 numpy array of integers
+        # where n is the number of samples.
+        indicies, reasons = filter_samples(v)
+        if indicies:
+            # add the reasons array to the format dictionary at this locus
+            v.set_format('FILTER_CODE', reasons)
+            for index in indicies:
+                # overwrite the genotypes of each filtered locus to be nocalls
+                # Note: until the reassignment to v.genotypes below, this
+                # leaves the v Variant object in an inconsistent state
+                v.genotypes[index] = [-1]*v.ploidy + [False]
+            # it is necessary to reassign the genotypes field
+            # so that the v Variant object reprocess it and future calls
+            # to functions like v.genotype.array() properly reflect
+            # the changed genotypes
+            v.genotypes = v.genotypes
+
+        w.write_record(v)
+
+    w.close(); vcf.close()
+
+.. _Limitations with writing:
+
+Known Limitations with Writing VCFs
+-----------------------------------
+* `cyvcf2` currently does not support writing VCFs encoded with UTF-8 with non-ASCII characters in the contents of string-typed FORMAT fields.
+* `cyvcf2` currently does not support writing string type format fields with number>1.
+


### PR DESCRIPTION
Does this demonstrate the blessed way of setting format fields and genotypes, or is there a cleaner/more efficient way that the documentation should espouse?

If this is logically correct, is it clear enough?