### PR TITLE
Add setter for CHROM

### DIFF
--- a/cyvcf2/cyvcf2.pyx
+++ b/cyvcf2/cyvcf2.pyx
@@ -1831,29 +1831,17 @@ cdef class Variant(object):
             return self.INFO.get(b'SVTYPE') is not None
 
     property CHROM:
-        """Chromosome of the variant.
-        To set this property, the new chromosome must have a contig entry in the header.
-        
-        Example:
-            >>> vcf = VCF(fname)
-            >>> new_chrom = "NEW"
-            >>> vcf.add_to_header("##contig=<ID={},length=15>".format(new_chrom))
-            >>> variant = next(vcf)
-            >>> # contig is in header
-            >>> variant.CHROM = new_chrom
-            >>> # contig is not in header
-            >>> try:
-            >>>     variant.CHROM = "foo"
-            >>> except ValueError as err:
-            >>>     assert "foo is not defined in the header" in str(err)
-        """
+        """Chromosome of the variant."""
         def __get__(self):
             return bcf_hdr_id2name(self.vcf.hdr, self.b.rid).decode()
 
         def __set__(self, new_chrom):
             new_rid = bcf_hdr_id2int(self.vcf.hdr, BCF_DT_CTG, new_chrom.encode())
             if new_rid < 0:
-                raise ValueError("{} is not defined in the header".format(new_chrom))
+                self.vcf.add_to_header("##contig=<ID={}>".format(new_chrom))
+                new_rid = bcf_hdr_id2int(self.vcf.hdr, BCF_DT_CTG, new_chrom.encode())
+                if new_rid < 0:
+                    raise ValueError("Unable to add {} to CHROM".format(new_chrom))
             self.b.rid = new_rid
 
     property var_type:

--- a/cyvcf2/cyvcf2.pyx
+++ b/cyvcf2/cyvcf2.pyx
@@ -295,6 +295,9 @@ cdef class VCF(HTSFile):
         ret = bcf_hdr_sync(self.hdr)
         if ret != 0:
             raise Exception("couldn't add '%s' to header")
+        if line.startswith("##contig"):
+            # need to trigger a refresh of seqnames
+            self._seqnames = []
         return ret
 
     def add_info_to_header(self, adict):
@@ -1842,6 +1845,9 @@ cdef class Variant(object):
                 new_rid = bcf_hdr_id2int(self.vcf.hdr, BCF_DT_CTG, new_chrom.encode())
                 if new_rid < 0:
                     raise ValueError("Unable to add {} to CHROM".format(new_chrom))
+                sys.stderr.write(
+                    "[cyvcf2]: added new contig {} to header".format(new_chrom)
+                )
             self.b.rid = new_rid
 
     property var_type:

--- a/cyvcf2/tests/test_reader.py
+++ b/cyvcf2/tests/test_reader.py
@@ -885,16 +885,23 @@ def test_set_chrom_when_contig_not_in_header():
     test_vcf = '{}/test-strict-gt-option-flag.vcf.gz'.format(HERE)
     new_chrom = "NEW"
     vcf = VCF(test_vcf, gts012=False)
+    original_seqnames = vcf.seqnames
+    assert new_chrom not in original_seqnames
     v = next(vcf)
 
     v.CHROM = new_chrom
     assert v.CHROM == new_chrom
+    expected_seqnames = sorted(original_seqnames + [new_chrom])
+    assert vcf.seqnames == expected_seqnames
 
 def test_set_chrom_after_contig_is_added_to_header():
     test_vcf = '{}/test-strict-gt-option-flag.vcf.gz'.format(HERE)
     new_chrom = "NEW"
     vcf = VCF(test_vcf, gts012=False)
+    original_seqnames = vcf.seqnames
     vcf.add_to_header("##contig=<ID={},length=15>".format(new_chrom))
+    expected_seqnames = sorted(original_seqnames + [new_chrom])
+    assert vcf.seqnames == expected_seqnames
     v = next(vcf)
 
     v.CHROM = new_chrom

--- a/cyvcf2/tests/test_reader.py
+++ b/cyvcf2/tests/test_reader.py
@@ -881,6 +881,25 @@ def test_set_pos():
     assert v.start == 22
     assert v.POS == 23
 
+def test_set_chrom_when_contig_not_in_header():
+    test_vcf = '{}/test-strict-gt-option-flag.vcf.gz'.format(HERE)
+    new_chrom = "NEW"
+    vcf = VCF(test_vcf, gts012=False)
+    v = next(vcf)
+
+    with assert_raises(ValueError):
+        v.CHROM = new_chrom
+
+def test_set_chrom_after_contig_is_added_to_header():
+    test_vcf = '{}/test-strict-gt-option-flag.vcf.gz'.format(HERE)
+    new_chrom = "NEW"
+    vcf = VCF(test_vcf, gts012=False)
+    vcf.add_to_header("##contig=<ID={},length=15>".format(new_chrom))
+    v = next(vcf)
+
+    v.CHROM = new_chrom
+    assert v.CHROM == new_chrom
+
 def test_set_qual():
     v = VCF(VCF_PATH)
     variant = next(v)

--- a/cyvcf2/tests/test_reader.py
+++ b/cyvcf2/tests/test_reader.py
@@ -887,8 +887,8 @@ def test_set_chrom_when_contig_not_in_header():
     vcf = VCF(test_vcf, gts012=False)
     v = next(vcf)
 
-    with assert_raises(ValueError):
-        v.CHROM = new_chrom
+    v.CHROM = new_chrom
+    assert v.CHROM == new_chrom
 
 def test_set_chrom_after_contig_is_added_to_header():
     test_vcf = '{}/test-strict-gt-option-flag.vcf.gz'.format(HERE)


### PR DESCRIPTION
This PR closes #167 

I hope this isn't too far away from how you would have implemented this @brentp?  

My only concern is that `seqnames` is not updated. But I wasn't sure if that is something you think we need to do? If so, how do you propose we do that? Would something like `self.vcf._seqnames = []` be enough? That way the next time that property is accessed it retriggers correctly gathering the names?