### PR TITLE
Fix issue 172

### DIFF
--- a/cyvcf2/cyvcf2.pyx
+++ b/cyvcf2/cyvcf2.pyx
@@ -1450,10 +1450,10 @@ cdef class Variant(object):
             ret = bcf_update_format_int32(self.vcf.hdr, self.b, to_bytes(name), &aint[0], size)
         elif np.issubdtype(data.dtype, np.floating):
             size = data.shape[0]
-            isnan = np.isnan(data)
             if len((<object>data).shape) > 1:
                 size *= data.shape[1]
             afloat = data.astype(np.float32).reshape((size,))
+            isnan = np.isnan(afloat)
             for i in range(size):
                 if isnan[i]:
                     bcf_float_set(&afloat[i], bcf_float_missing)

--- a/cyvcf2/cyvcf2.pyx
+++ b/cyvcf2/cyvcf2.pyx
@@ -1429,7 +1429,7 @@ cdef class Variant(object):
     def set_format(self, name, np.ndarray data not None):
         """
         set the format field given by name..
-        data must be a numpy array of type float or int
+        data must be a numpy array of type float, int or string (fixed length ASCII np.bytes_)
         """
         cdef int n_samples = self.vcf.n_samples
         if len(data) % n_samples != 0:
@@ -1452,6 +1452,7 @@ cdef class Variant(object):
             if len((<object>data).shape) > 1:
                 size *= data.shape[1]
             afloat = data.astype(np.float32).reshape((size,))
+            afloat[afloat == np.nan] = bcf_float_missing
             ret = bcf_update_format_float(self.vcf.hdr, self.b, to_bytes(name), &afloat[0], size)
         elif np.issubdtype(data.dtype, np.bytes_):
             if len((<object>data).shape) > 1:

--- a/cyvcf2/tests/test_reader.py
+++ b/cyvcf2/tests/test_reader.py
@@ -1125,3 +1125,16 @@ def test_no_seqlen():
     with assert_raises(AttributeError) as ae:
         vcf.seqlens
     assert isinstance(ae.exception, AttributeError)
+
+def test_set_unknown_format():
+    vcf = VCF(VCF_PATH)
+    vcf.add_format_to_header({'ID':'NEW', 'Type':'Float', 'Number':1, 'Description':'...'})
+
+    v = next(vcf)
+    arr = np.array([[1.1] for s in vcf.samples])
+    arr[-1][0] = np.nan
+    v.set_format('NEW', arr)
+    record = str(v)
+    parts = record.split()
+    assert parts[-1][-1] == '.'
+    assert parts[-2][-3:] == '1.1'


### PR DESCRIPTION
I believe this fixes issue https://github.com/brentp/cyvcf2/issues/172

This is supposed to cause cyvcf2 to write out '.' instead of 'nan' when it encounters np.nan in format fields.

Rationale per [this comment](https://github.com/samtools/htslib/issues/664#issuecomment-370793241) on an htslib issue.

I no longer have an environment where I can compile and test cyvcf2 - do you have time to double check this works? If not I can try to get my environment back to a usable state. I'm currently seeing the error
```
Failure: ImportError (/projects/ps-gymreklab/jmargoli/cyvcf2/cyvcf2/cyvcf2.cpython-37m-x86_64-linux-gnu.so: undefined symbol: libdeflate_free_decompressor) ... ERROR
```