### PR TITLE
Use GitHub Actions for continuous integration #183

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,34 @@
+name: Build
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    name: Run tests on Python ${{ matrix.python-version }}
+    runs-on: ubuntu-18.04
+    strategy:
+      matrix:
+        python-version: [3.5, 3.6, 3.7, 3.8]
+
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        submodules: true
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install
+      run: |
+        sudo apt-get install libcurl4-openssl-dev
+        pip install -r requirements.txt
+        cd htslib
+        autoheader && autoconf
+        ./configure --enable-s3 --disable-lzma --disable-bz2
+        make
+        cd ..
+        CYTHONIZE=1 python setup.py install
+    - name: Test
+      run: |
+        python setup.py test
+

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -1,0 +1,53 @@
+name: Wheels
+
+on: [push, pull_request]
+
+jobs:
+  build_wheels:
+    name: Build wheels on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-18.04, macos-latest]
+
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        submodules: true
+    - uses: actions/setup-python@v2
+      name: Install Python
+      with:
+        python-version: "3.7"
+
+    - name: Install cibuildwheel
+      run: |
+        python -m pip install cibuildwheel
+
+    - name: Build wheels for Linux
+      if: matrix.os == 'ubuntu-18.04'
+      run: |
+        python -m cibuildwheel --output-dir wheelhouse
+      env:
+        CIBW_SKIP: "pp* cp27-* cp34-* *i686*"
+        CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
+        CIBW_BEFORE_BUILD_LINUX: "{project}/ci/linux-deps"
+        CIBW_TEST_COMMAND: "{project}/ci/test"
+        CIBW_ENVIRONMENT: "CYTHONIZE=1 LDFLAGS='-L/usr/lib64/openssl11' CPPFLAGS='-I/usr/include/openssl11' C_INCLUDE_PATH='/root/include' LIBRARY_PATH='/root/lib'"
+
+    - name: Build wheels for Mac OS
+      if: matrix.os == 'macos-latest'
+      run: |
+        python -m cibuildwheel --output-dir wheelhouse
+      env:
+        CIBW_SKIP: "pp* cp27-* cp34-* *i686*"
+        CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
+        CIBW_BEFORE_BUILD_MACOS: "{project}/ci/osx-deps"
+        CIBW_TEST_COMMAND: "{project}/ci/test"
+        CIBW_ENVIRONMENT: "CYTHONIZE=1"
+        LDFLAGS: "-L/usr/local/opt/openssl@1.1/lib"
+        CPPFLAGS: "-I/usr/local/opt/openssl@1.1/include"
+        PKG_CONFIG_PATH: "/usr/local/opt/openssl@1.1/lib/pkgconfig"
+
+    - uses: actions/upload-artifact@v2
+      with:
+        path: ./wheelhouse/*.whl


### PR DESCRIPTION
This addresses #183. It's a simple translation of @horta's work from Travis to GitHub Actions.

I've tested the resulting Python 3.7 wheel on Mac (it only seems to work on Catalina/Mac 10.15 or later, since libcrypto was build for that version).

I haven't included a step to deploy to PyPI - that could be added here or in a separate PR.