### PR TITLE
Upload wheels and source dist to pypi

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -54,3 +54,41 @@ jobs:
     - uses: actions/upload-artifact@v2
       with:
         path: ./wheelhouse/*.whl
+
+  build_sdist:
+    name: Build source distribution
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: actions/setup-python@v2
+        name: Install Python
+        with:
+          python-version: "3.7"
+
+      - name: Build sdist
+        run: python setup.py sdist
+
+      - uses: actions/upload-artifact@v2
+        with:
+          path: dist/*.tar.gz
+
+  upload_pypi:
+    needs: [build_wheels, build_sdist]
+    runs-on: ubuntu-latest
+    # upload to PyPI on every tag starting with 'v'
+    if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags/v')
+    steps:
+      - uses: actions/download-artifact@v2
+        with:
+          name: artifact
+          path: dist
+
+      - uses: pypa/gh-action-pypi-publish@master
+        with:
+          user: __token__
+          # Test configuration (delete these two lines once it's working)
+          password: ${{ secrets.TEST_PYPI_API_TOKEN }}
+          repository_url: https://test.pypi.org/legacy/
+          # Main configuration (uncomment once test works)
+          # password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -87,8 +87,4 @@ jobs:
       - uses: pypa/gh-action-pypi-publish@master
         with:
           user: __token__
-          # Test configuration (delete these two lines once it's working)
-          password: ${{ secrets.TEST_PYPI_API_TOKEN }}
-          repository_url: https://test.pypi.org/legacy/
-          # Main configuration (uncomment once test works)
-          # password: ${{ secrets.PYPI_API_TOKEN }}
+          password: ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
This should be what's needed to upload to pypi, modelled on https://github.com/joerick/cibuildwheel/blob/master/examples/github-deploy.yml. I haven't tested it since I don't have permission to upload to cyvcf2's pypi repository (or the test one), so @brentp or @horta - would you be able to give this a go? The docs for this GitHub action are at https://github.com/pypa/gh-action-pypi-publish.

Also, I added a section to build a source distribution, which I assume is a good idea. If so, should we rename `wheels.yml` to `release.yml` or similar?