### PR TITLE
Make sure the source tarball (by sdist) is cythonized

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -1,6 +1,6 @@
 name: Wheels
 
-on: 
+on:
   push:
     tags:
       - 'v*.*.*'
@@ -58,6 +58,8 @@ jobs:
   build_sdist:
     name: Build source distribution
     runs-on: ubuntu-latest
+    env:
+      CYTHONIZE: 1
     steps:
       - uses: actions/checkout@v2
 


### PR DESCRIPTION
The releases are now managed by GitHub workflow (by PR #186), but the source tarball generation didn't enable `CYTHONIZE=1`. We expect the general downstream users don't need Cython to generate the C code, so the source tarball need to include the Cython output. 

I enable cython with [the environment variable][env-var], which should fix #196. I am not familiar with GitHub Workflow, so perhaps @tomwhite and others can help review the change.

[env-var]: https://docs.github.com/en/actions/reference/environment-variables