### PR TITLE
change test vcf version to 5b

### DIFF
--- a/scripts/compare.sh
+++ b/scripts/compare.sh
@@ -1,3 +1,4 @@
+# This is a record of comparisons made in the cyvcf2 paper. These vcf filenames are now different and may not work to run the tests
 chrom=22
 
 if [[ ! -e ALL.chr${chrom}.phase3_shapeit2_mvncall_integrated_v5a.20130502.genotypes.vcf.gz ]]; then


### PR DESCRIPTION
For the speed comparisons, all the vcf files in the 1000 genomes release have been changed to v5b.