### PR TITLE
Drop Python 3.5 for Mac wheel (already dropped for Linux wheel)

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -48,7 +48,7 @@ jobs:
       run: |
         python -m cibuildwheel --output-dir wheelhouse
       env:
-        CIBW_SKIP: "pp* cp27-* cp34-* *i686*"
+        CIBW_SKIP: "pp* cp27-* cp34-* cp35-* *i686*"
         CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
         CIBW_BEFORE_BUILD_MACOS: "{project}/ci/osx-deps"
         CIBW_TEST_COMMAND: "{project}/ci/test"


### PR DESCRIPTION
The Mac build was overlooked in e712f36f6b30f2843f75e430bfcd330bd3d01613, which is now causing the wheel build to fail, since cibuildwheel 2 doesn't support Python < 3.6.