### PR TITLE
Downgrade autoconf to fix configure issue on mac

### DIFF
--- a/ci/osx-deps
+++ b/ci/osx-deps
@@ -5,6 +5,12 @@ python -m pip install pip --upgrade
 git submodule init
 git submodule update
 
+# configure fails with autoconf 2.71, so downgrade
+# see https://github.com/asdf-vm/asdf-erlang/issues/195
+brew install autoconf@2.69 && \
+brew link --overwrite autoconf@2.69 && \
+autoconf -V
+
 cd htslib
 autoheader
 autoconf


### PR DESCRIPTION
This fixes mac wheels for #205 (but the full wheel build will still fail because linux is still failing).

Tested here: https://github.com/tomwhite/cyvcf2/actions/runs/1045921914