### PR TITLE
Downgrade autoconf to fix configure issue on linux

### DIFF
--- a/ci/linux-deps
+++ b/ci/linux-deps
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 yum install -y openssl11-devel
 yum install -y libffi libffi-devel zlib-devel
 yum install -y bzip2-devel bzip2-libs xz-devel xz-libs
@@ -28,8 +30,10 @@ cd ..
 rm -rf curl-7.73.0
 
 cd htslib
-autoheader
-autoconf
+# configure fails with autoconf 2.71 (in /usr/local/bin), so use 2.69 (in /usr/bin)
+/usr/bin/autoconf -V
+/usr/bin/autoheader
+/usr/bin/autoconf
 ./configure --enable-libcurl --enable-s3 --enable-lzma --enable-bz2
 make
 

--- a/ci/osx-deps
+++ b/ci/osx-deps
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 python -m pip install pip --upgrade
 
 git submodule init


### PR DESCRIPTION
It turns out to be the same problem on linux as mac: autoconf 2.71 prints an error and so the default configuration is used.

Fixed by using autoconf 2.69 (from /usr/bin). Also added a `set -e` to get a build failure if any of the script commands fail.

Tested here: https://github.com/tomwhite/cyvcf2/runs/3112466015?check_suite_focus=true