### PR TITLE
Build wheels on every push to master

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -2,6 +2,8 @@ name: Wheels
 
 on:
   push:
+    branches:
+      - master
     tags:
       - 'v*.*.*'
   workflow_dispatch:


### PR DESCRIPTION
This will run the wheel build more frequently so it's easier to track when things break.

BTW it would be a good idea to rename to 'main' #213.