### PR TITLE
Avoid a Python 3.10 regression in iterating GzipFiles

### DIFF
--- a/cyvcf2/tests/test_reader.py
+++ b/cyvcf2/tests/test_reader.py
@@ -484,16 +484,17 @@ def test_var_type():
 def _get_line_for(v):
     import gzip
 
-    for i, line in enumerate(gzip.open(VCF_PATH), start=1):
-        line = line.decode()
-        if line[0] == "#": continue
-        toks = line.strip().split("\t")
-        if not (toks[0] == v.CHROM and int(toks[1]) == v.POS): continue
-        if toks[3] != v.REF: continue
-        if toks[4] not in v.ALT: continue
-        return toks
-    else:
-        raise Exception("not found")
+    with gzip.open(VCF_PATH) as f:
+        for i, line in enumerate(f, start=1):
+            line = line.decode()
+            if line[0] == "#": continue
+            toks = line.strip().split("\t")
+            if not (toks[0] == v.CHROM and int(toks[1]) == v.POS): continue
+            if toks[3] != v.REF: continue
+            if toks[4] not in v.ALT: continue
+            return toks
+        else:
+            raise Exception("not found")
 
 
 def _get_samples(v):


### PR DESCRIPTION
Open the file with a context manager, so we're holding onto a reference to it, for the lifetime of the iteration.

This avoids hitting https://bugs.python.org/issue45475 which affects python3.10 3.10.0-4 in Debian.