### PR TITLE
Remove some deprecated items and test Python 3.10.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-18.04
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: [3.6, 3.7, 3.8, 3.9, "3.10"]
 
     steps:
     - uses: actions/checkout@v2
@@ -23,14 +23,14 @@ jobs:
         sudo apt-get update
         sudo apt-get install libcurl4-openssl-dev
         pip install -r requirements.txt
-        pip install nose
+        pip install pytest pytest-cov
         cd htslib
         autoheader && autoconf
         ./configure --enable-s3 --disable-lzma --disable-bz2
         make
         cd ..
-        CYTHONIZE=1 python setup.py install
+        CYTHONIZE=1 python setup.py build_ext -i
     - name: Test
       run: |
-        python setup.py test
+        pytest --cov cyvcf2 --cov-report term-missing
 

--- a/README.md
+++ b/README.md
@@ -107,10 +107,10 @@ For pkg-config to find openssl you may need to set:
 Testing
 =======
 
-Tests can be run with:
+Install `pytest`, then tests can be run with:
 
 ```
-python setup.py test
+pytest
 ```
 
 CLI

--- a/cyvcf2/cyvcf2.pyx
+++ b/cyvcf2/cyvcf2.pyx
@@ -1704,8 +1704,8 @@ cdef class Variant(object):
         def __get__(self):
             if self.vcf.n_samples == 0:
                 return []
-            t = np.array(self.gt_depths, np.float)
-            a = np.array(self.gt_alt_depths, np.float)
+            t = np.array(self.gt_depths, float)
+            a = np.array(self.gt_alt_depths, float)
 
             # for which samples are the alt or total depths unknown?
             tU = t < 0

--- a/cyvcf2/tests/test_hemi.py
+++ b/cyvcf2/tests/test_hemi.py
@@ -1,7 +1,6 @@
 import numpy as np
 from cyvcf2 import VCF, Variant, Writer
 import os.path
-from nose.tools import assert_raises
 
 HERE = os.path.dirname(__file__)
 HEM_PATH = os.path.join(HERE, "test-hemi.vcf")

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -131,11 +131,11 @@ or via bioconda.
 Testing
 =======
 
-Tests can be run with:
+Install `pytest`, then tests can be run with:
 
 .. code-block:: bash
 
-    python setup.py test
+    pytest
 
 Known Limitations
 =================

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,2 @@
-[nosetests]
-verbosity=1
-detailed-errors=1
-with-coverage=1
-stop=1
+[tool:pytest]
+testpaths = cyvcf2/tests

--- a/setup.py
+++ b/setup.py
@@ -96,8 +96,6 @@ setup(
             'cyvcf2 = cyvcf2.__main__:cli',
         ],
     ),
-    test_suite='nose.collector',
-    tests_require='nose',
     install_requires=['numpy', 'coloredlogs', 'click'],
     include_package_data=True,
     zip_safe=False,


### PR DESCRIPTION
- Remove nose (not maintained since 2016) in favour of pytest. Closes #226.
- Use `int`/`float` instead of `np.int`/`np.float`. Closes #202.
- Setuptools have deprecated 'python setup.py test', so remove.