### PR TITLE
Use oldest-supported-numpy when building wheels

### DIFF
--- a/ci/linux-deps
+++ b/ci/linux-deps
@@ -6,8 +6,6 @@ yum install -y openssl11-devel
 yum install -y libffi libffi-devel zlib-devel
 yum install -y bzip2-devel bzip2-libs xz-devel xz-libs
 
-python -m pip install pip --upgrade
-
 git submodule init
 git submodule update
 
@@ -43,6 +41,3 @@ cd htslib
 /usr/bin/autoconf
 ./configure --enable-libcurl --enable-s3 --enable-lzma --enable-bz2
 make
-
-cd ..
-pip install -r requirements.txt

--- a/ci/osx-deps
+++ b/ci/osx-deps
@@ -2,8 +2,6 @@
 
 set -e
 
-python -m pip install pip --upgrade
-
 git submodule init
 git submodule update
 
@@ -25,6 +23,3 @@ autoheader
 autoconf
 ./configure --enable-libcurl --enable-s3 --enable-lzma --enable-bz2
 make
-
-cd ..
-pip install -r requirements.txt

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,2 @@
+[build-system]
+requires = ["setuptools", "wheel", "cython>=0.23.3", "oldest-supported-numpy"]

--- a/setup.py
+++ b/setup.py
@@ -5,14 +5,12 @@ import subprocess
 import platform
 
 import pkg_resources
-from setuptools import setup, Extension, dist
+from setuptools import setup, Extension
 
 if sys.version_info.major == 2 and sys.version_info.minor != 7:
     sys.stderr.write("ERROR: cyvcf2 is only for python 2.7 or greater you are running %d.%d\n", (sys.version_info.major, sys.version_info.minor))
     sys.exit(1)
 
-# Install numpy right now
-dist.Distribution().fetch_build_eggs(['numpy'])
 import numpy as np
 
 


### PR DESCRIPTION
Fixes #248 by following @grahamgower's suggestion of using `oldest-supported-numpy`.

I tested this by allowing GH actions to build wheels [here](https://github.com/tomwhite/cyvcf2/actions/runs/3097525978). Note that this runs tests for the wheels against the latest version of NumPy; to test against an older version NumPy too I downloaded and unzipped the artifact from that page, then in a fresh venv:

```
%  pip install ~/Downloads/artifact/cyvcf2-0.30.16-cp38-cp38-macosx_10_9_x86_64.whl
Processing /Users/tom/Downloads/artifact/cyvcf2-0.30.16-cp38-cp38-macosx_10_9_x86_64.whl
Collecting numpy
  Using cached numpy-1.23.3-cp38-cp38-macosx_10_9_x86_64.whl (18.1 MB)
Collecting click
  Using cached click-8.1.3-py3-none-any.whl (96 kB)
Collecting coloredlogs
  Using cached coloredlogs-15.0.1-py2.py3-none-any.whl (46 kB)
Collecting humanfriendly>=9.1
  Using cached humanfriendly-10.0-py2.py3-none-any.whl (86 kB)
Installing collected packages: numpy, humanfriendly, click, coloredlogs, cyvcf2
Successfully installed click-8.1.3 coloredlogs-15.0.1 cyvcf2-0.30.16 humanfriendly-10.0 numpy-1.23.3
%  cyvcf2 --help
Usage: cyvcf2 [OPTIONS] <vcf_file> or -

  fast vcf parsing with cython + htslib

Options:
  -c, --chrom TEXT                Specify what chromosome to include.
  -s, --start INTEGER             Specify the start of region.
  -e, --end INTEGER               Specify the end of the region.
  --include TEXT                  Specify what info field to include.
  --exclude TEXT                  Specify what info field to exclude.
  -i, --individual TEXT           Only print genotype call for individual.
  --no-inds                       Do not print genotypes.
  --loglevel [DEBUG|INFO|WARNING|ERROR|CRITICAL]
                                  Set the level of log output.  [default:
                                  INFO]
  --silent                        Skip printing of vcf.
  --help                          Show this message and exit.
%  pip install -U numpy==1.22
Collecting numpy==1.22
  Using cached numpy-1.22.0-cp38-cp38-macosx_10_9_x86_64.whl (17.6 MB)
Installing collected packages: numpy
  Attempting uninstall: numpy
    Found existing installation: numpy 1.23.3
    Uninstalling numpy-1.23.3:
      Successfully uninstalled numpy-1.23.3
Successfully installed numpy-1.22.0
%  cyvcf2 --help  
Usage: cyvcf2 [OPTIONS] <vcf_file> or -

  fast vcf parsing with cython + htslib

Options:
  -c, --chrom TEXT                Specify what chromosome to include.
  -s, --start INTEGER             Specify the start of region.
  -e, --end INTEGER               Specify the end of the region.
  --include TEXT                  Specify what info field to include.
  --exclude TEXT                  Specify what info field to exclude.
  -i, --individual TEXT           Only print genotype call for individual.
  --no-inds                       Do not print genotypes.
  --loglevel [DEBUG|INFO|WARNING|ERROR|CRITICAL]
                                  Set the level of log output.  [default:
                                  INFO]
  --silent                        Skip printing of vcf.
  --help                          Show this message and exit.
```

Compare this to the error message I got in #248.