### PR TITLE
Build macos arm64 wheels without libdeflate

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -46,18 +46,38 @@ jobs:
         CIBW_ENVIRONMENT: "CYTHONIZE=1 LIBDEFLATE=1 LDFLAGS='-L/usr/lib64/openssl11' CPPFLAGS='-I/usr/include/openssl11' C_INCLUDE_PATH='/root/include' LIBRARY_PATH='/root/lib'"
         CIBW_REPAIR_WHEEL_COMMAND_LINUX: LD_LIBRARY_PATH='/root/lib' auditwheel repair -w {dest_dir} {wheel}
 
-    - name: Build wheels for Mac OS
+    - name: Build wheels for Mac OS x86
       if: matrix.os == 'macos-latest'
       run: |
         python -m cibuildwheel --output-dir wheelhouse
       env:
         CIBW_SKIP: "pp* *i686*"
-        CIBW_ARCHS_MACOS: "x86_64 arm64"
+        CIBW_ARCHS_MACOS: "x86_64"
         CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
         CIBW_BEFORE_BUILD_MACOS: "{project}/ci/osx-deps"
         CIBW_TEST_COMMAND: "{project}/ci/test"
-        CIBW_TEST_SKIP: "*-macosx_arm64"
         CIBW_ENVIRONMENT: "CYTHONIZE=1 LIBDEFLATE=1 C_INCLUDE_PATH='/usr/local/include' LIBRARY_PATH='/usr/local/lib'"
+        # https://cibuildwheel.readthedocs.io/en/stable/faq/#macos-passing-dyld_library_path-to-delocate
+        CIBW_REPAIR_WHEEL_COMMAND_MACOS: >
+          DYLD_LIBRARY_PATH=/usr/local/lib delocate-listdeps {wheel} &&
+          DYLD_LIBRARY_PATH=/usr/local/lib delocate-wheel --require-archs {delocate_archs} -w {dest_dir} {wheel}
+        LDFLAGS: "-L/usr/local/opt/openssl@1.1/lib"
+        CPPFLAGS: "-I/usr/local/opt/openssl@1.1/include"
+        PKG_CONFIG_PATH: "/usr/local/opt/openssl@1.1/lib/pkgconfig"
+
+    - name: Build wheels for Mac OS arm64
+      # don't build with libdeflate, see https://github.com/brentp/cyvcf2/issues/252
+      if: matrix.os == 'macos-latest'
+      run: |
+        python -m cibuildwheel --output-dir wheelhouse
+      env:
+        CIBW_SKIP: "pp* *i686*"
+        CIBW_ARCHS_MACOS: "arm64"
+        CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
+        CIBW_BEFORE_BUILD_MACOS: "{project}/ci/osx-arm64-deps"
+        CIBW_TEST_COMMAND: "{project}/ci/test"
+        CIBW_TEST_SKIP: "*-macosx_arm64"
+        CIBW_ENVIRONMENT: "CYTHONIZE=1 C_INCLUDE_PATH='/usr/local/include' LIBRARY_PATH='/usr/local/lib'"
         # https://cibuildwheel.readthedocs.io/en/stable/faq/#macos-passing-dyld_library_path-to-delocate
         CIBW_REPAIR_WHEEL_COMMAND_MACOS: >
           DYLD_LIBRARY_PATH=/usr/local/lib delocate-listdeps {wheel} &&

--- a/ci/osx-arm64-deps
+++ b/ci/osx-arm64-deps
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+set -e
+
+git submodule init
+git submodule update
+
+# configure fails with autoconf 2.71, so downgrade
+# see https://github.com/asdf-vm/asdf-erlang/issues/195
+brew install autoconf@2.69 && \
+brew link --overwrite autoconf@2.69 && \
+autoconf -V
+
+cd htslib
+autoheader
+autoconf
+./configure --enable-libcurl --enable-s3 --enable-lzma --enable-bz2 --without-libdeflate
+make


### PR DESCRIPTION
Fixes #252.

The only way I could get this to work was by having a separate call to cibuildwheel, with a different script in `CIBW_BEFORE_BUILD_MACOS` (`osx-arm64-deps`) that doesn't compile with libdeflate.

(Before that, I tried using `arch` in `osx-deps` to detect if it's x86 or arm64, but of course that doesn't work since arm64 is cross compiled on x86.)