### PR TITLE
Fix for issue #17

### DIFF
--- a/cyvcf2/cyvcf2.pyx
+++ b/cyvcf2/cyvcf2.pyx
@@ -1494,6 +1494,8 @@ cdef class Variant(object):
             if self._gt_types == NULL:
                 self._gt_phased = <int *>stdlib.malloc(sizeof(int) * self.vcf.n_samples)
                 ngts = bcf_get_genotypes(self.vcf.hdr, self.b, &self._gt_types, &ndst)
+                if ngts < 0:
+                    raise Exception(f"error parsing genotypes")
                 nper = int(ngts / self.vcf.n_samples)
                 self._ploidy = nper
                 self._gt_idxs = <int *>stdlib.malloc(sizeof(int) * self.vcf.n_samples * nper)

--- a/cyvcf2/cyvcf2.pyx
+++ b/cyvcf2/cyvcf2.pyx
@@ -1495,7 +1495,7 @@ cdef class Variant(object):
                 self._gt_phased = <int *>stdlib.malloc(sizeof(int) * self.vcf.n_samples)
                 ngts = bcf_get_genotypes(self.vcf.hdr, self.b, &self._gt_types, &ndst)
                 if ngts < 0:
-                    raise Exception(f"error parsing genotypes")
+                    raise Exception("error parsing genotypes")
                 nper = int(ngts / self.vcf.n_samples)
                 self._ploidy = nper
                 self._gt_idxs = <int *>stdlib.malloc(sizeof(int) * self.vcf.n_samples * nper)

--- a/cyvcf2/cyvcf2.pyx
+++ b/cyvcf2/cyvcf2.pyx
@@ -1495,7 +1495,7 @@ cdef class Variant(object):
                 self._gt_phased = <int *>stdlib.malloc(sizeof(int) * self.vcf.n_samples)
                 ngts = bcf_get_genotypes(self.vcf.hdr, self.b, &self._gt_types, &ndst)
                 if ngts < 0:
-                    raise Exception("error parsing genotypes")
+                    raise Exception("error parsing genotypes; they may be absent from this record")
                 nper = int(ngts / self.vcf.n_samples)
                 self._ploidy = nper
                 self._gt_idxs = <int *>stdlib.malloc(sizeof(int) * self.vcf.n_samples * nper)

--- a/cyvcf2/tests/test-no-genotypes.vcf
+++ b/cyvcf2/tests/test-no-genotypes.vcf
@@ -3,8 +3,4 @@
 ##FORMAT=<ID=PL,Number=G,Type=Integer,Description="Normalized, Phred-scaled likelihoods for genotypes as defined in the VCF specification">
 ##contig=<ID=1,length=249250621,assembly=b37>
 #CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	samplea	sampleb
-1	8466747	.	A	C	.	PASS	.	GT:PL	.:.	1:36,0
-1	8466747	.	A	C	.	PASS	.	GT:PL	./.:.	./1:36,0,40
 1	8466747	.	A	T	.	PASS	.	PL	.	36,0
-1	8466747	.	A	T	.	PASS	.	GT	0/1	0
-1	8466747	.	A	T	.	PASS	.	GT	0	0/1

--- a/cyvcf2/tests/test-no-genotypes.vcf
+++ b/cyvcf2/tests/test-no-genotypes.vcf
@@ -1,0 +1,10 @@
+##fileformat=VCFv4.1
+##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">
+##FORMAT=<ID=PL,Number=G,Type=Integer,Description="Normalized, Phred-scaled likelihoods for genotypes as defined in the VCF specification">
+##contig=<ID=1,length=249250621,assembly=b37>
+#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	samplea	sampleb
+1	8466747	.	A	C	.	PASS	.	GT:PL	.:.	1:36,0
+1	8466747	.	A	C	.	PASS	.	GT:PL	./.:.	./1:36,0,40
+1	8466747	.	A	T	.	PASS	.	PL	.	36,0
+1	8466747	.	A	T	.	PASS	.	GT	0/1	0
+1	8466747	.	A	T	.	PASS	.	GT	0	0/1

--- a/cyvcf2/tests/test_reader.py
+++ b/cyvcf2/tests/test_reader.py
@@ -1320,10 +1320,6 @@ def test_issue236():
 
 def test_issue17_no_gt():
     vcf = VCF(os.path.join(HERE, "test-no-genotypes.vcf"))
-    for v in vcf:
-        try:
+    with pytest.raises(Exception):
+        for v in vcf:
             v.num_called  # Used to give segmentation fault
-        except:
-            pass
-
-    assert True

--- a/cyvcf2/tests/test_reader.py
+++ b/cyvcf2/tests/test_reader.py
@@ -1316,3 +1316,14 @@ def test_issue236():
 
         assert res[0] == res[1]
         assert len(res[0]) > 0
+
+
+def test_issue17_no_gt():
+    vcf = VCF(os.path.join(HERE, "test-no-genotypes.vcf"))
+    for v in vcf:
+        try:
+            v.num_called  # Used to give segmentation fault
+        except:
+            pass
+
+    assert True


### PR DESCRIPTION
Fix for issue https://github.com/brentp/cyvcf2/issues/17

This adds a check for bcf_get_genotypes returning -1, returning same exception as other methods when calling GT methods w/o GT present, avoiding segmentation fault
