### PR TITLE
Prevent memory leak if user calls VCF.close()

### DIFF
--- a/cyvcf2/cyvcf2.pyx
+++ b/cyvcf2/cyvcf2.pyx
@@ -559,7 +559,7 @@ cdef class VCF(HTSFile):
     contains = __contains__
 
     def __dealloc__(self):
-        if self.hts != NULL and self.hdr != NULL:
+        if self.hdr != NULL:
             bcf_hdr_destroy(self.hdr)
             self.hdr = NULL
         self.close()


### PR DESCRIPTION
Currently, if the following code is run, memory use increases with every iteration of the loop:

```python
import sys
from cyvcf2 import VCF, Variant

def open_vcf():
    vcf = VCF(sys.argv[1])
    vcf.close()

for i in range(1000):
    open_vcf()
```

This is because `vcf.__dealloc__` checks the value of `vcf.hts` before calling `bcf_hdr_destroy`. `vcf.close` has already set the value of  `vcf.hts` to `NULL`. So `bcf_hdr_destroy` does not get called, leading to leaking the memory that `bcf_hdr_read` allocated in `vcf.__init__`.

The full (long) context is at https://github.com/pystatgen/sgkit-publication/issues/35 where we can easily fix this by not calling `close`, but I thought it worth adding a fix here to save others headaches!
