### PR TITLE
Fix wheel build

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -31,7 +31,7 @@ jobs:
     - uses: actions/setup-python@v4
       name: Install Python
       with:
-        python-version: "3.7"
+        python-version: "3.12"
 
     - name: Install cibuildwheel
       run: |
@@ -91,7 +91,7 @@ jobs:
 
     # Enable tmate debugging of manually-triggered workflows if the input option was provided
     - name: Setup tmate session
-      if: ${{ always() && github.event_name == 'workflow_dispatch' && github.event.inputs.debug_enabled }}
+      if: ${{ always() && github.event_name == 'workflow_dispatch' && github.event.inputs.debug_enabled == 'true' }}
       uses: mxschmitt/action-tmate@v3
 
     - uses: actions/upload-artifact@v2
@@ -104,10 +104,10 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v4
         name: Install Python
         with:
-          python-version: "3.7"
+          python-version: "3.12"
 
       - name: Install dependencies
         run: |

--- a/ci/linux-deps
+++ b/ci/linux-deps
@@ -10,7 +10,7 @@ git submodule init
 git submodule update
 git submodule update --init --recursive
 
-curl -O https://www.libssh2.org/download/libssh2-1.9.0.tar.gz
+curl -L -O https://www.libssh2.org/download/libssh2-1.9.0.tar.gz
 tar xzf libssh2-1.9.0.tar.gz
 cd libssh2-1.9.0
 ./configure --prefix=/root
@@ -19,7 +19,7 @@ make install
 cd ..
 rm -rf libssh2-1.9.0
 
-curl -O https://curl.se/download/curl-7.73.0.tar.gz
+curl -L -O https://curl.se/download/curl-7.73.0.tar.gz
 tar xzf curl-7.73.0.tar.gz
 cd curl-7.73.0
 ./configure --with-libssh2 --prefix=/root


### PR DESCRIPTION
I noticed that pypi hasn't been updated with the latest versions, and that 3.12 wheels are not being built.

This branch aims to fix this.

- Fix issue where curl don't follow symlinks
- Use python 3.12 to build wheels. The latest cibuildwheels doesn't support 3.7, and thus an older version of cibuildwheels is used. This older version doesn't create python 3.12 wheels.

Workflow: https://github.com/oyvinev/cyvcf2/actions/runs/7168362176

![image](https://github.com/brentp/cyvcf2/assets/4920368/4faed076-2c08-4cad-b835-be188941f772)
![image](https://github.com/brentp/cyvcf2/assets/4920368/51747a07-bb76-4341-b148-2b36aa1dc6bc)
![image](https://github.com/brentp/cyvcf2/assets/4920368/b20d237a-c4cd-448b-a294-6336fd48bc8d)
