### PR TITLE
Add missing macos arm64 wheel.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -207,7 +207,7 @@ jobs:
 
       - name: Upload sdist tarball
         if: runner.os == 'Linux'
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: sdist
           path: dist/cyvcf2-*.tar.gz

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -27,8 +27,8 @@ jobs:
           - [ubuntu-22.04, musllinux_x86_64]
           - [ubuntu-22.04, manylinux_aarch64]
           - [ubuntu-22.04, musllinux_aarch64]
-          # macOS build arm64 on x86_64 with cross-compiler
           - [macos-12, macosx_x86_64]
+          - [macos-12, macosx_arm64]
         python-version: [pp310, cp37, cp38, cp39, cp310, cp311, cp312]
         exclude:
           # pp310, cp37, cp38 on musllinux is not support
@@ -49,6 +49,11 @@ jobs:
             python-version: cp310
           - buildplat: [ubuntu-22.04, musllinux_aarch64]
             python-version: pp310
+          # cp37, pp310 on macos arm64 is not supported
+          - buildplat: [macos-12, macosx_arm64]
+            python-version: cp37
+          - buildplat: [macos-12, macosx_arm64]
+            python-version: pp310
 
     steps:
       - uses: actions/checkout@v4
@@ -60,7 +65,7 @@ jobs:
         uses: docker/setup-qemu-action@v3
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.16.2
+        uses: pypa/cibuildwheel@v2.16.4
         with:
           package-dir: .
           output-dir: wheelhouse
@@ -88,6 +93,8 @@ jobs:
             CYVCF2_HTSLIB_CONFIGURE_OPTIONS="--enable-libcurl --enable-s3 --enable-lzma --enable-bz2 --with-libdeflate"
             CYTHONIZE=1
           CIBW_TEST_COMMAND: "{project}/ci/test"
+          # macOS build arm64 on x86_64 with cross-compiler, not support test
+          CIBW_TEST_SKIP: "macosx_arm64"
 
       # Enable tmate debugging of manually-triggered workflows if the input option was provided
       - name: Setup tmate session

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -94,15 +94,16 @@ jobs:
             CYTHONIZE=1
           CIBW_TEST_COMMAND: "{project}/ci/test"
           # macOS build arm64 on x86_64 with cross-compiler, not support test
-          CIBW_TEST_SKIP: "macosx_arm64"
+          CIBW_TEST_SKIP: "*-macosx_arm64"
 
       # Enable tmate debugging of manually-triggered workflows if the input option was provided
       - name: Setup tmate session
         if: ${{ always() && github.event_name == 'workflow_dispatch' && github.event.inputs.debug_enabled == 'true' }}
         uses: mxschmitt/action-tmate@v3
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
+          name: artifact-${{ matrix.python-version }}-${{ matrix.buildplat[1] }}
           path: ./wheelhouse/*.whl
 
   build_sdist:
@@ -124,8 +125,9 @@ jobs:
       - name: Build sdist
         run: CYTHONIZE=1 python setup.py sdist
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
+          name: artifact-sdist
           path: dist/*.tar.gz
 
   upload_pypi:
@@ -134,9 +136,10 @@ jobs:
     # upload to PyPI on every tag starting with 'v'
     if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags/v')
     steps:
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
-          name: artifact
+          pattern: artifact-*
+          merge-multiple: true
           path: dist
 
       - uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
Add missing macos arm64 wheel. #297 
And fix the deprecated warning on actions

> Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/setup-python@v4, actions/upload-artifact@v3. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.
