### PR TITLE
add CI test for lowest supported runtime version of numpy

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -110,6 +110,7 @@ jobs:
         run: |
           pytest --cov cyvcf2 --cov-report term-missing
 
+      # make sure to keep this numpy version in sync with setup.py
       - name: Test with oldest numpy that we support
         if: contains(fromJson('["3.7"]'), matrix.python-version)
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -113,7 +113,7 @@ jobs:
       - name: Test with oldest numpy that we support
         if: contains(fromJson('["3.7", "3.8", "3.9"]'), matrix.python-version)
         run: |
-          pip install --force-reinstall --no-cache-dir 'numpy==1.21.0'
+          pip install --force-reinstall --no-cache-dir 'numpy==1.20.3'
           pytest --cov cyvcf2 --cov-report term-missing
 
       - name: Test with newest available numpy

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -110,6 +110,11 @@ jobs:
         run: |
           pytest --cov cyvcf2 --cov-report term-missing
 
+      - name: Test with oldest numpy that we support
+        run: |
+          pip install --force-reinstall --no-cache-dir 'numpy==1.21.0'
+          pytest --cov cyvcf2 --cov-report term-missing
+
   windows_build:
     name: Run tests on Python windows-2022 MSYS2 UCRT64
     runs-on: windows-2022
@@ -164,6 +169,11 @@ jobs:
         run: |
           pytest --cov cyvcf2 --cov-report term-missing
 
+      - name: Test with oldest numpy that we support
+        run: |
+          pip install --force-reinstall --no-cache-dir 'numpy==1.21.0'
+          pytest --cov cyvcf2 --cov-report term-missing
+
   sdist:
     runs-on: ubuntu-22.04
     strategy:
@@ -205,6 +215,11 @@ jobs:
 
       - name: Test
         run: |
+          pytest --import-mode importlib --cov cyvcf2 --cov-report term-missing
+
+      - name: Test with oldest numpy that we support
+        run: |
+          pip install --force-reinstall --no-cache-dir 'numpy==1.21.0'
           pytest --import-mode importlib --cov cyvcf2 --cov-report term-missing
 
       - name: Upload sdist tarball

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -115,6 +115,11 @@ jobs:
           pip install --force-reinstall --no-cache-dir 'numpy==1.21.0'
           pytest --cov cyvcf2 --cov-report term-missing
 
+      - name: Test with newest available numpy
+        run: |
+          pip install -U numpy
+          pytest --cov cyvcf2 --cov-report term-missing
+
   windows_build:
     name: Run tests on Python windows-2022 MSYS2 UCRT64
     runs-on: windows-2022
@@ -174,6 +179,11 @@ jobs:
           pip install --force-reinstall --no-cache-dir 'numpy==1.21.0'
           pytest --cov cyvcf2 --cov-report term-missing
 
+      - name: Test with newest available numpy
+        run: |
+          pip install -U numpy
+          pytest --cov cyvcf2 --cov-report term-missing
+
   sdist:
     runs-on: ubuntu-22.04
     strategy:
@@ -220,6 +230,11 @@ jobs:
       - name: Test with oldest numpy that we support
         run: |
           pip install --force-reinstall --no-cache-dir 'numpy==1.21.0'
+          pytest --import-mode importlib --cov cyvcf2 --cov-report term-missing
+
+      - name: Test with newest available numpy
+        run: |
+          pip install -U numpy
           pytest --import-mode importlib --cov cyvcf2 --cov-report term-missing
 
       - name: Upload sdist tarball

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -118,7 +118,6 @@ jobs:
           pytest --cov cyvcf2 --cov-report term-missing
 
       - name: Test with newest available numpy
-        if: ${{ matrix.python-version }} != "3.7" && ${{ matrix.python-version }} != "3.8"
         run: |
           pip install -U numpy
           pytest --cov cyvcf2 --cov-report term-missing

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -111,11 +111,13 @@ jobs:
           pytest --cov cyvcf2 --cov-report term-missing
 
       - name: Test with oldest numpy that we support
+        if: contains(fromJson('["3.7", "3.8", "3.9"]'), matrix.python-version)
         run: |
           pip install --force-reinstall --no-cache-dir 'numpy==1.21.0'
           pytest --cov cyvcf2 --cov-report term-missing
 
       - name: Test with newest available numpy
+        if: ${{ matrix.python-version }} != "3.7" && ${{ matrix.python-version }} != "3.8"
         run: |
           pip install -U numpy
           pytest --cov cyvcf2 --cov-report term-missing
@@ -174,11 +176,6 @@ jobs:
         run: |
           pytest --cov cyvcf2 --cov-report term-missing
 
-      - name: Test with oldest numpy that we support
-        run: |
-          pip install --force-reinstall --no-cache-dir 'numpy==1.21.0'
-          pytest --cov cyvcf2 --cov-report term-missing
-
       - name: Test with newest available numpy
         run: |
           pip install -U numpy
@@ -225,11 +222,6 @@ jobs:
 
       - name: Test
         run: |
-          pytest --import-mode importlib --cov cyvcf2 --cov-report term-missing
-
-      - name: Test with oldest numpy that we support
-        run: |
-          pip install --force-reinstall --no-cache-dir 'numpy==1.21.0'
           pytest --import-mode importlib --cov cyvcf2 --cov-report term-missing
 
       - name: Test with newest available numpy

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -111,9 +111,9 @@ jobs:
           pytest --cov cyvcf2 --cov-report term-missing
 
       - name: Test with oldest numpy that we support
-        if: contains(fromJson('["3.7", "3.8", "3.9"]'), matrix.python-version)
+        if: contains(fromJson('["3.7"]'), matrix.python-version)
         run: |
-          pip install --force-reinstall --no-cache-dir 'numpy==1.20.3'
+          pip install --force-reinstall --no-cache-dir 'numpy==1.16.0'
           pytest --cov cyvcf2 --cov-report term-missing
 
       - name: Test with newest available numpy

--- a/setup.py
+++ b/setup.py
@@ -290,7 +290,7 @@ setup(
         ],
     ),
     python_requires=">=3.7",
-    install_requires=["numpy", "coloredlogs", "click"],
+    install_requires=["numpy>=1.21.0", "coloredlogs", "click"],
     include_package_data=True,
     zip_safe=False,
     cmdclass={

--- a/setup.py
+++ b/setup.py
@@ -290,6 +290,7 @@ setup(
         ],
     ),
     python_requires=">=3.7",
+    # make sure to keep this numpy version in sync with build.yml
     install_requires=["numpy>=1.16.0", "coloredlogs", "click"],
     include_package_data=True,
     zip_safe=False,

--- a/setup.py
+++ b/setup.py
@@ -290,7 +290,7 @@ setup(
         ],
     ),
     python_requires=">=3.7",
-    install_requires=["numpy>=1.21.0", "coloredlogs", "click"],
+    install_requires=["numpy>=1.20.3", "coloredlogs", "click"],
     include_package_data=True,
     zip_safe=False,
     cmdclass={

--- a/setup.py
+++ b/setup.py
@@ -290,7 +290,7 @@ setup(
         ],
     ),
     python_requires=">=3.7",
-    install_requires=["numpy>=1.20.3", "coloredlogs", "click"],
+    install_requires=["numpy>=1.16.0", "coloredlogs", "click"],
     include_package_data=True,
     zip_safe=False,
     cmdclass={


### PR DESCRIPTION
Following up on https://github.com/brentp/cyvcf2/issues/307#issuecomment-2174539396, I added CI tests for the oldest and newest versions of numpy. I chose numpy 1.16 as the oldest compatible version of numpy, since it's the oldest version that still works with python 3.7 and the setup.py file already requires at least 3.7 anyway

Please note that the CI does not test that oldest version against macos or windows, since the runners in the CI use a version of python unsupported by numpy 1.16