### PR TITLE
Allow Reader/Writer to be context managers

### DIFF
--- a/cyvcf2/cyvcf2.pyx
+++ b/cyvcf2/cyvcf2.pyx
@@ -293,6 +293,12 @@ cdef class VCF(HTSFile):
         if threads is not None:
             self.set_threads(threads)
 
+    def __enter__(self):
+        return self
+
+    def __exit__(self, type, value, tb):
+        self.close()
+
     def set_threads(self, int n):
         v = hts_set_threads(self.hts, n)
         if v < 0:
@@ -2413,6 +2419,12 @@ cdef class Writer(VCF):
         self.hdr = bcf_hdr_dup(tmpl.hdr)
         bcf_hdr_sync(self.hdr)
         self.header_written = False
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, type, value, tb):
+        self.close()
 
     @staticmethod
     def _infer_file_mode(fname, mode=None):

--- a/cyvcf2/cyvcf2.pyx
+++ b/cyvcf2/cyvcf2.pyx
@@ -2420,12 +2420,6 @@ cdef class Writer(VCF):
         bcf_hdr_sync(self.hdr)
         self.header_written = False
 
-    def __enter__(self):
-        return self
-
-    def __exit__(self, type, value, tb):
-        self.close()
-
     @staticmethod
     def _infer_file_mode(fname, mode=None):
         if mode is not None:

--- a/cyvcf2/tests/test_reader.py
+++ b/cyvcf2/tests/test_reader.py
@@ -1410,3 +1410,9 @@ def test_num_records_no_index(path):
     vcf = VCF(os.path.join(HERE, path))
     with pytest.raises(ValueError, match="must be indexed"):
         vcf.num_records
+
+def test_reader_context_manager():
+    with VCF(VCF_PATH) as vcf:
+        pass
+    with pytest.raises(Exception, match="attempt to iterate over closed"):
+        next(vcf)


### PR DESCRIPTION
By adding `__enter__` and `__exit__` methods to the Reader and Writer classes, they can now be used as context managers. Also added a test to make sure the Reader context manager works correctly. Did not add a test to do the same with Writer, because trying to write to a closed Writer results in a segfault rather than raising an exception that can be checked by pytest.