### PR TITLE
Fix wheels

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -28,7 +28,7 @@ jobs:
           - [ubuntu-22.04, musllinux_x86_64]
           - [ubuntu-22.04, manylinux_aarch64]
           - [ubuntu-22.04, musllinux_aarch64]
-          - [macos-12, macosx_x86_64]
+          - [macos-13, macosx_x86_64]
           - [macos-14, macosx_arm64]
         python-version: [pp310, cp38, cp39, cp310, cp311, cp312, cp313]
         exclude:


### PR DESCRIPTION
PyPy needed enabling and the GitHub runners for OSX 12 have been turned off.