### PR TITLE
Fix gt_bases/gt_phases dropping phasing when the first allele is missing (#331)

### DIFF
--- a/cyvcf2/cyvcf2.pyx
+++ b/cyvcf2/cyvcf2.pyx
@@ -1374,6 +1374,10 @@ cdef class Variant(object):
                 j += 1
                 if n == 2:
                     if (gt_types[j] == unknown) and (not self.vcf.strict_gt):
+                        # issue #331: a fully-missing diploid genotype (e.g. .|.) is
+                        # UNKNOWN; emit the phase-aware separator instead of the "./."
+                        # default so a phased .|. renders as .|. rather than ./.
+                        bases[j] = "." + lookup[phased[j]] + "."
                         continue
                     else:
                         a = self._gt_idxs[i]
@@ -1713,7 +1717,14 @@ cdef class Variant(object):
                         else:
                             self._gt_idxs[k] = a
 
-                    self._gt_phased[j] = self._gt_types[i] > 0 and <int>bcf_gt_is_phased(self._gt_types[i+1])
+                    # issue #331: _gt_types still holds the raw htslib encoding here
+                    # (as_gts runs below). A missing first allele encodes to 0, so the
+                    # old "_gt_types[i] > 0" gate wrongly dropped phasing whenever the
+                    # first allele was missing. The phase bit lives on the second allele,
+                    # so mirror the `genotypes` property and read it directly. `nper > 1`
+                    # preserves haploid (no phasing) and guards the i+1 access; the
+                    # vector_end check handles mixed-ploidy records padded to nper.
+                    self._gt_phased[j] = nper > 1 and self._gt_types[i+1] != bcf_int32_vector_end and <int>bcf_gt_is_phased(self._gt_types[i+1])
                     j += 1
 
                 if self.vcf.gts012:

--- a/cyvcf2/tests/issue_331.vcf
+++ b/cyvcf2/tests/issue_331.vcf
@@ -1,0 +1,7 @@
+##fileformat=VCFv4.3
+##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">
+##contig=<ID=chr1,length=10000000>
+##contig=<ID=chr2,length=10000000>
+#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	ind_1	ind_2	ind_3	ind_4	ind_5
+chr1	1	snp_phased	A	G	.	PASS	.	GT	0|.	1|.	.|.	.|0	.|1
+chr2	1	snp_unphased	A	G	.	PASS	.	GT	0/.	1/.	./.	./0	./1

--- a/cyvcf2/tests/test_reader.py
+++ b/cyvcf2/tests/test_reader.py
@@ -215,6 +215,19 @@ def test_phases():
     v = next(vcf)
     assert not any(v.gt_phases)
 
+def test_phased_missing_gt_bases():
+    # issue #331: gt_bases dropped phasing when the first allele was missing,
+    # rendering "/" (and "./.") for phased genotypes such as .|. and .|0.
+    vcf = VCF(os.path.join(HERE, "issue_331.vcf"))
+
+    v = next(vcf)  # snp_phased: 0|. 1|. .|. .|0 .|1
+    assert list(v.gt_bases) == ['A|.', 'G|.', '.|.', '.|A', '.|G'], v.gt_bases
+    assert list(v.gt_phases) == [True] * 5, v.gt_phases
+
+    v = next(vcf)  # snp_unphased: 0/. 1/. ./. ./0 ./1
+    assert list(v.gt_bases) == ['A/.', 'G/.', './.', './A', './G'], v.gt_bases
+    assert list(v.gt_phases) == [False] * 5, v.gt_phases
+
 def test_bad_init():
     with pytest.raises(Exception):
         VCF("XXXXX")


### PR DESCRIPTION
Fixes #331.

## Problem
`Variant.gt_bases` / `Variant.gt_phases` drop phasing when the FIRST allele of a genotype is missing. For GT `0|.,1|.,.|.,.|0,.|1`, gt_bases returned `['A|.','G|.','./.','./A','./G']` (last three wrong) and gt_phases returned `[True,True,False,False,False]`, while `Variant.genotypes` correctly reports phased=True for all five -- an internal inconsistency.

## Root cause
In the `gt_types` getter, `_gt_phased` is computed from `_gt_types`, which at that point still holds the RAW htslib encoding (the `as_gts` categorization runs just afterwards). The old code gated on `self._gt_types[i] > 0` -- i.e. the first allele -- but a missing first allele encodes to 0, so phasing was forced off even though the phase bit lives on the SECOND allele. The `genotypes` property reads the phase bit directly with no such gate, hence the mismatch.

## Fix
- Mirror the `genotypes` property: read the phase bit from the second allele. `nper > 1` preserves haploid (unphased) and guards the `i+1` access; a `bcf_int32_vector_end` check handles mixed-ploidy records padded to `nper`.
- Secondary: in `gt_bases`, the fully-missing diploid (`.|.`, which categorizes to UNKNOWN) fell through to the `./.` default, ignoring phase. It now emits the phase-aware separator so a phased `.|.` renders as `.|.`.

## Tests
Added `cyvcf2/tests/issue_331.vcf` (the reporter's example) and `test_phased_missing_gt_bases` asserting the phased row renders `['A|.','G|.','.|.','.|A','.|G']` with `gt_phases == [True]*5`, and that the unphased row is unchanged. Verified red->green (the phasing assertions fail before the fix, pass after) and the full suite passes (120 passed) with no regression on the shared haploid / multiallelic / gts012 paths.

This change was prepared with AI assistance and reviewed by me before submission.