### PR TITLE
Expose Variant.errcode (closes #163)

### DIFF
--- a/cyvcf2/cyvcf2.pxd
+++ b/cyvcf2/cyvcf2.pxd
@@ -118,6 +118,12 @@ cdef extern from "htslib/vcf.h":
     cdef extern uint32_t bcf_float_missing;
 
     cdef extern const int BCF_ERR_CTG_UNDEF;
+    cdef extern const int BCF_ERR_TAG_UNDEF;
+    cdef extern const int BCF_ERR_NCOLS;
+    cdef extern const int BCF_ERR_LIMITS;
+    cdef extern const int BCF_ERR_CHAR;
+    cdef extern const int BCF_ERR_CTG_INVALID;
+    cdef extern const int BCF_ERR_TAG_INVALID;
 
 
     cdef extern const int BCF_BT_NULL;

--- a/cyvcf2/cyvcf2.pyx
+++ b/cyvcf2/cyvcf2.pyx
@@ -1275,6 +1275,39 @@ cdef inline Genotypes newGenotypes(int32_t *raw, int ploidy, int n_samples):
     gs.n_samples = n_samples
     return gs
 
+#: Mapping of htslib ``BCF_ERR_*`` bit flags to a short description.
+#: A record's :attr:`Variant.errcode` is a bitwise OR of these values.
+BCF_ERROR_FLAGS = {
+    BCF_ERR_CTG_UNDEF: "contig not defined in the header",
+    BCF_ERR_TAG_UNDEF: "INFO/FORMAT tag not defined in the header",
+    BCF_ERR_NCOLS: "wrong number of columns",
+    BCF_ERR_LIMITS: "value exceeds a format limit",
+    BCF_ERR_CHAR: "invalid character",
+    BCF_ERR_CTG_INVALID: "invalid contig",
+    BCF_ERR_TAG_INVALID: "invalid tag",
+}
+
+
+def describe_errcode(errcode):
+    """Return a readable description of a :attr:`Variant.errcode` value.
+
+    >>> describe_errcode(0)
+    'no error'
+    """
+    if errcode == 0:
+        return "no error"
+    known = 0
+    parts = []
+    for flag in sorted(BCF_ERROR_FLAGS):
+        known |= flag
+        if errcode & flag:
+            parts.append(BCF_ERROR_FLAGS[flag])
+    leftover = errcode & ~known
+    if leftover:
+        parts.append("unrecognized flag %d" % leftover)
+    return "; ".join(parts)
+
+
 cdef class Variant(object):
     """
     Variant represents a single VCF Record.
@@ -2216,6 +2249,17 @@ cdef class Variant(object):
             cdef int n = self.b.d.n_flt
             return [from_bytes(bcf_hdr_int2id(self.vcf.hdr, BCF_DT_ID, self.b.d.flt[i])) for i in range(n)]
 
+    property errcode:
+        """htslib error flags for this record; 0 when the record is clean.
+
+        The value is a bitwise OR of the ``BCF_ERR_*`` flags listed in
+        :data:`BCF_ERROR_FLAGS`. htslib's ``vcf.h`` notes that this field
+        "must be checked before calling bcf_write()". Use
+        :func:`describe_errcode` for a readable form.
+        """
+        def __get__(self):
+            return self.b.errcode
+
     property QUAL:
         "the float value of QUAL from the VCF field."
         def __get__(self):
@@ -2617,7 +2661,8 @@ cdef class Writer(VCF):
                 raise Exception("error adding contig %d to header" % var.b.rid)
             bcf_hdr_sync(self.hdr)
         elif var.b.errcode != 0:
-            raise Exception("variant to be written has errorcode: %d" % var.b.errcode)
+            raise Exception("variant to be written has errorcode %d (%s)" % (
+                var.b.errcode, describe_errcode(var.b.errcode)))
         return bcf_write(self.hts, self.hdr, var.b)
 
     def close(Writer self):

--- a/cyvcf2/tests/test_reader.py
+++ b/cyvcf2/tests/test_reader.py
@@ -14,7 +14,7 @@ import warnings
 import numpy as np
 import pytest
 
-from ..cyvcf2 import VCF, Variant, Writer
+from ..cyvcf2 import VCF, Variant, Writer, BCF_ERROR_FLAGS, describe_errcode
 
 
 HERE = os.path.dirname(__file__)
@@ -28,6 +28,40 @@ try:
     basestring
 except NameError:
     basestring = (str, bytes)
+
+def test_errcode_is_exposed():
+    """Variant.errcode surfaces the htslib error flags for a record.
+
+    htslib's vcf.h says of this field that it "must be checked before
+    calling bcf_write()"; before this was exposed there was no way to do
+    that from Python. Records in a well-formed file should all be clean.
+    """
+    vcf = VCF(VCF_PATH)
+    for i, v in enumerate(vcf):
+        assert isinstance(v.errcode, int)
+        assert v.errcode == 0, (i, v.errcode, describe_errcode(v.errcode))
+        if i > 50:
+            break
+
+
+def test_describe_errcode():
+    assert describe_errcode(0) == "no error"
+
+    # every documented flag maps to its own description
+    for flag, msg in BCF_ERROR_FLAGS.items():
+        assert describe_errcode(flag) == msg
+
+    # errcode is a bit field, so combinations report every flag set
+    flags = sorted(BCF_ERROR_FLAGS)
+    combined = flags[0] | flags[1]
+    described = describe_errcode(combined)
+    assert BCF_ERROR_FLAGS[flags[0]] in described
+    assert BCF_ERROR_FLAGS[flags[1]] in described
+
+    # bits htslib may add later are reported rather than silently dropped
+    unknown = 1 << 20
+    assert "unrecognized flag %d" % unknown == describe_errcode(unknown)
+
 
 def test_init():
     # string


### PR DESCRIPTION
Closes #163.

## Why

htslib sets `bcf1_t.errcode` to a bitwise OR of the `BCF_ERR_*` flags, and `vcf.h` says of that field:

> set to one of BCF_ERR* codes and must be checked before calling bcf_write().

cyvcf2 reads `b.errcode` internally in seven places but never exposed it, so there was no way to do that check from Python.

The sharpest symptom is in `Writer.write_record`:

```python
elif var.b.errcode != 0:
    raise Exception("variant to be written has errorcode: %d" % var.b.errcode)
```

A caller gets `variant to be written has errorcode: 2` — a raw integer they could not have inspected beforehand and cannot interpret afterwards without reading htslib's headers.

## What changed

**`cyvcf2/cyvcf2.pxd`** — declares the six `BCF_ERR_*` constants that were missing. Only `BCF_ERR_CTG_UNDEF` was declared; the values are taken from htslib's `vcf.h` (`BCF_ERR_TAG_UNDEF` 2, `BCF_ERR_NCOLS` 4, `BCF_ERR_LIMITS` 8, `BCF_ERR_CHAR` 16, `BCF_ERR_CTG_INVALID` 32, `BCF_ERR_TAG_INVALID` 64).

**`Variant.errcode`** — returns `self.b.errcode`, following the existing `property`/`__get__` style used by `QUAL` and its neighbours.

**`BCF_ERROR_FLAGS`** — a module-level dict mapping each flag to a short description, so the integer is interpretable without leaving Python.

**`describe_errcode(errcode)`** — renders a value. It decomposes the bit field rather than assuming a single flag, and reports any bit htslib may add in future as `unrecognized flag N` instead of silently dropping it.

**`write_record`** — the exception now names the flag as well as the number.

That last hunk is separable. If you would rather keep this to the property alone, drop it and the rest still stands.

## Tests

Two added to `test_reader.py`:

- `test_errcode_is_exposed` — `errcode` is an int and is 0 for every record in a well-formed file.
- `test_describe_errcode` — covers zero, each individual flag, a combination of two flags, and an unrecognized bit.

## Verification, and its limit

I could not complete a local build: htslib's configure needs `autoconf`/`automake`, which are not installed here, and I did not want to change the machine's toolchain to find out. So this has **not** been run through the test suite locally, and CI should be treated as the real check.

What I did verify is the part I actually changed. Cythonizing `cyvcf2.pyx` before and after the patch produces an **identical warning set** (5 warnings both ways, all pre-existing and in untouched code), and the generated C contains the new symbols. So the Cython is syntactically sound and the `extern` declarations resolve; what remains unproven locally is only linkage and runtime behaviour.

Happy to adjust naming, drop the `write_record` hunk, or split this if you would prefer it smaller.
