### PR TITLE
raise on vcf_parse failure instead of yielding a bad record

### DIFF
--- a/cyvcf2/cyvcf2.pyx
+++ b/cyvcf2/cyvcf2.pyx
@@ -560,10 +560,10 @@ cdef class VCF(HTSFile):
                             ret = vcf_parse(&s, self.hdr, b)
                     if slen <= 0:
                         break
-                    if ret > 0:
+                    if ret != 0:
                         bcf_destroy(b)
                         # s.s and itr are released by the finally block
-                        raise Exception("error parsing")
+                        raise Exception("error parsing: vcf_parse returned %d" % ret)
                     yield newVariant(b, self)
             finally:
                 stdlib.free(s.s)
@@ -598,10 +598,10 @@ cdef class VCF(HTSFile):
                             ret = vcf_parse(&s, self.hdr, b)
                 if slen <= 0:
                     break
-                if ret > 0:
+                if ret != 0:
                     bcf_destroy(b)
                     # s.s and itr are released by the finally block
-                    raise Exception("error parsing")
+                    raise Exception("error parsing: vcf_parse returned %d" % ret)
                 yield newVariant(b, self)
         finally:
             stdlib.free(s.s)
@@ -2587,10 +2587,10 @@ cdef class Writer(VCF):
         s.m = len(variant_string) + 1
 
         ret = vcf_parse(&s, self.hdr, b)
-        if ret > 0:
+        if ret != 0:
             bcf_destroy(b)
             ks_free(&s)
-            raise Exception("error parsing:" + variant_string + " return value:" + ret)
+            raise Exception("error parsing: %s (vcf_parse returned %d)" % (variant_string, ret))
 
         var = newVariant(b, self)
         if var.b.errcode == BCF_ERR_CTG_UNDEF:

--- a/cyvcf2/tests/test_reader.py
+++ b/cyvcf2/tests/test_reader.py
@@ -285,6 +285,21 @@ def test_writer_from_string():
     w.write_record(v)
     w.close()
 
+def test_variant_from_string_malformed():
+    # vcf_parse() returns 0 on success and a negative value on failure, so a
+    # malformed line must raise rather than return a partially-filled record.
+    # Reading REF or ID off such a record segfaults.
+    header = """##fileformat=VCFv4.1
+##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">
+##contig=<ID=chr1,length=249250621,assembly=hg19>
+#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	samplea
+"""
+
+    w = Writer.from_string(tempfile.mktemp(suffix=".vcf"), header)
+    with pytest.raises(Exception, match="error parsing"):
+        w.variant_from_string("chr1\tNOTANUMBER\t.\tA\tC\t40\tPASS\t.\tGT\t0/0")
+    w.close()
+
 def test_isa():
     vcf = VCF(os.path.join(HERE, "test.isa.vcf"))
     for i, v in enumerate(vcf):

--- a/cyvcf2/tests/test_reader.py
+++ b/cyvcf2/tests/test_reader.py
@@ -295,7 +295,9 @@ def test_variant_from_string_malformed():
 #CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	samplea
 """
 
-    w = Writer.from_string(tempfile.mktemp(suffix=".vcf"), header)
+    output_path = tempfile.mktemp(suffix=".vcf")
+    atexit.register(os.unlink, output_path)
+    w = Writer.from_string(output_path, header)
     with pytest.raises(Exception, match="error parsing"):
         w.variant_from_string("chr1\tNOTANUMBER\t.\tA\tC\t40\tPASS\t.\tGT\t0/0")
     w.close()


### PR DESCRIPTION
## Problem
`vcf_parse()` returns 0 on success and -1/-2 on failure. It never returns a positive value, so the three `ret > 0` checks never fire and the parse failure checks are silently ignored.

In `Writer.variant_from_string` the consequence is a segfault reachable with the following code:

```python
w = Writer.from_string(path, header)
v = w.variant_from_string("chr1\tNOTANUMBER\t.\tA\tC\t40\tPASS\t.\tGT\t0/0")
v.CHROM   # 'chr1'  -- no exception was raised
v.REF     # Segmentation fault (core dumped)
```

`vcf_parse` logs `[E::vcf_parse] Could not parse the position 'NOTANUMBER'` and bails out via its `err` label. The record comes from `bcf_init()`, zeroed from calloc. `vcf_parse` aborts at POS before `shared` (with ID/REF/ALT) is populated. `newVariant` calls `bcf_unpack`, which returns immediately with `if ( !b->shared.l ) return 0;` and leaves `d.allele` and `d.id` as NULL. Reading .REF or .ID de-references them, leading to segfault. 

## Fix
Test `ret != 0` instead of `ret > 0` at all three `vcf_parse` call sites. This matches the convention already used everywhere else in the file (e.g. lines 364, 448, 2172).

Also fixes the exception message in `variant_from_string`, which concatenated a `str` with an `int` and so would have raised `TypeError` rather than the intended message had it ever been reachable.

## Note on scope
The two region-iteration call sites have the same defect but are harder to exercise in a test, since it requires a bgzip+tabix-indexed file whose index builds while a line still fails to parse. They are fixed here because it is the same one-line defect. The added test covers the `variant_from_string` path only.

This does change behavior for malformed input in indexed files: previously a partially filled record was yielded silently, now an exception is raised.